### PR TITLE
fix: SMS storage info on ME-default modems + duplicated APN profiles from stale bearers

### DIFF
--- a/backend/src/modem_manager.rs
+++ b/backend/src/modem_manager.rs
@@ -845,6 +845,15 @@ fn sms_storage_cache_entry_for_identity(
     db.get_sms_storage_cache(&[identity_key]).ok().flatten()
 }
 
+/// 缓存的存储条目若无 total（此前抓取失败写入的 "empty" 占位），视为不完整。
+/// 仅用于后台刷新流程内部的重试判断；不影响 sim_details_cache_missing 的
+/// 自动触发语义（空占位在 ICCID 变化前不重复触发探测）。
+fn sms_storage_cache_incomplete(db: &Database, identity: &SimIdentity) -> bool {
+    sms_storage_cache_entry_for_identity(db, identity)
+        .map(|entry| entry.sms_total.is_none())
+        .unwrap_or(true)
+}
+
 fn cache_sms_storage_for_identity(
     db: &Database,
     identity: &SimIdentity,
@@ -1870,7 +1879,7 @@ async fn refresh_sim_details_background_inner(conn: &Connection, db: &Database, 
         cache_smsc_for_identity(db, &identity, &sms_center, source);
     }
 
-    if force || sms_storage_cache_entry_for_identity(db, &identity).is_none() {
+    if force || sms_storage_cache_incomplete(db, &identity) {
         let mut storage = None;
         if let Some(path) = modem_path.as_deref() {
             if let Ok(output) = send_at_via_modem_command(conn, path, "AT+CPMS?").await {
@@ -1943,36 +1952,40 @@ async fn active_protocol_smsc_fallback(conn: &Connection, modem_path: &str) -> S
     .unwrap_or_default()
 }
 
+fn parse_sms_storage_count(field: &str) -> Option<u32> {
+    let cleaned: String = field
+        .trim_matches('"')
+        .trim_matches('\'')
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    cleaned.parse::<u32>().ok()
+}
+
+/// 解析 AT+CPMS? 回复中的短信存储用量。
+/// 优先取 SIM 卡存储（"SM"）；部分模组默认存储为模组内存（"ME"），
+/// 回复中不含 "SM" 三元组，此时回退取第一个有效存储。
 fn parse_sms_storage_info(at_output: &str) -> Option<(u32, u32)> {
-    if let Some(pos) = at_output.find("+CPMS:") {
-        let line = &at_output[pos + 6..];
-        let parts: Vec<&str> = line.split(',').map(|s| s.trim()).collect();
-        for chunk in parts.chunks(3) {
-            if chunk.len() >= 3 {
-                let mem = chunk[0].trim_matches('"').trim_matches('\'');
+    let pos = at_output.find("+CPMS:")?;
+    let line = &at_output[pos + 6..];
+    let parts: Vec<&str> = line.split(',').map(|s| s.trim()).collect();
+    let mut fallback = None;
+    for chunk in parts.chunks(3) {
+        if chunk.len() >= 3 {
+            let mem = chunk[0].trim_matches('"').trim_matches('\'');
+            let used = parse_sms_storage_count(chunk[1]);
+            let total = parse_sms_storage_count(chunk[2]);
+            if let (Some(u), Some(t)) = (used, total) {
                 if mem == "SM" {
-                    let used_clean: String = chunk[1]
-                        .trim_matches('"')
-                        .trim_matches('\'')
-                        .chars()
-                        .take_while(|c| c.is_ascii_digit())
-                        .collect();
-                    let total_clean: String = chunk[2]
-                        .trim_matches('"')
-                        .trim_matches('\'')
-                        .chars()
-                        .take_while(|c| c.is_ascii_digit())
-                        .collect();
-                    let used = used_clean.parse::<u32>().ok();
-                    let total = total_clean.parse::<u32>().ok();
-                    if let (Some(u), Some(t)) = (used, total) {
-                        return Some((u, t));
-                    }
+                    return Some((u, t));
+                }
+                if fallback.is_none() {
+                    fallback = Some((u, t));
                 }
             }
         }
     }
-    None
+    fallback
 }
 
 pub async fn get_sim_info_data_with_cache(
@@ -2732,8 +2745,9 @@ LTE Timing Advance: 'unavailable'"#;
         let output_2 = "+CPMS: \"ME\",5,50,\"SM\",10,30\n\rOK";
         assert_eq!(parse_sms_storage_info(output_2), Some((10, 30)));
 
-        let output_invalid = "+CPMS: \"ME\",5,50";
-        assert_eq!(parse_sms_storage_info(output_invalid), None);
+        // 无 SM 三元组时回退取 ME 存储（如 QMI 直连的 Quectel 模组）
+        let output_me_only = "+CPMS: \"ME\",5,50";
+        assert_eq!(parse_sms_storage_info(output_me_only), Some((5, 50)));
     }
 
     #[test]
@@ -3038,6 +3052,85 @@ LTE Timing Advance: 'unavailable'"#;
             unsupported,
             vec!["LTE B8".to_string(), "NR n78".to_string()]
         );
+    }
+
+    #[test]
+    fn parses_sms_storage_from_sim_triple() {
+        let output = r#"+CPMS: "SM",3,50,"SM",3,50,"SM",3,50"#;
+        assert_eq!(parse_sms_storage_info(output), Some((3, 50)));
+    }
+
+    #[test]
+    fn parses_sms_storage_falls_back_to_modem_memory() {
+        // Quectel QMI 模组默认存储为 ME，回复中不含 SM 三元组
+        let output = r#"+CPMS: "ME",0,255,"ME",0,255,"ME",0,255"#;
+        assert_eq!(parse_sms_storage_info(output), Some((0, 255)));
+    }
+
+    #[test]
+    fn parses_sms_storage_prefers_sim_over_modem_memory() {
+        let output = r#"+CPMS: "ME",7,255,"SM",3,50,"ME",7,255"#;
+        assert_eq!(parse_sms_storage_info(output), Some((3, 50)));
+    }
+
+    #[test]
+    fn parses_sms_storage_rejects_garbage() {
+        assert_eq!(parse_sms_storage_info("ERROR"), None);
+        assert_eq!(parse_sms_storage_info("+CPMS: \"ME\",x,y"), None);
+    }
+
+    fn apn_ctx(path: &str, context_type: &str, apn: &str, protocol: &str, active: bool) -> ApnContext {
+        ApnContext {
+            path: path.to_string(),
+            name: path.rsplit('/').next().unwrap_or("bearer").to_string(),
+            active,
+            apn: apn.to_string(),
+            protocol: protocol.to_string(),
+            username: String::new(),
+            password: String::new(),
+            auth_method: "chap".to_string(),
+            context_type: context_type.to_string(),
+        }
+    }
+
+    #[test]
+    fn dedups_stale_data_bearers_keeps_attach() {
+        let contexts = vec![
+            apn_ctx("/mm/Bearer/0", APN_CONTEXT_TYPE_ATTACH, "MORE", "ip", true),
+            apn_ctx("/mm/Bearer/1", "internet", "more", "dual", false),
+            apn_ctx("/mm/Bearer/2", "internet", "more", "dual", false),
+        ];
+
+        let deduped = dedup_apn_contexts(contexts);
+
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(deduped[0].context_type, APN_CONTEXT_TYPE_ATTACH);
+        // 两个重复的数据承载仅保留最新的
+        assert_eq!(deduped[1].path, "/mm/Bearer/2");
+    }
+
+    #[test]
+    fn dedups_data_bearers_prefers_connected() {
+        let contexts = vec![
+            apn_ctx("/mm/Bearer/1", "internet", "more", "dual", true),
+            apn_ctx("/mm/Bearer/2", "internet", "more", "dual", false),
+        ];
+
+        let deduped = dedup_apn_contexts(contexts);
+
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].path, "/mm/Bearer/1");
+        assert!(deduped[0].active);
+    }
+
+    #[test]
+    fn keeps_distinct_apn_contexts() {
+        let contexts = vec![
+            apn_ctx("/mm/Bearer/1", "internet", "more", "dual", false),
+            apn_ctx("/mm/Bearer/2", "internet", "ims", "dual", false),
+        ];
+
+        assert_eq!(dedup_apn_contexts(contexts).len(), 2);
     }
 }
 
@@ -4470,6 +4563,9 @@ const MM_BEARER: &str = "org.freedesktop.ModemManager1.Bearer";
 const MM_BEARER_ALLOWED_AUTH_NONE: u32 = 1 << 0;
 const MM_BEARER_ALLOWED_AUTH_PAP: u32 = 1 << 1;
 const MM_BEARER_ALLOWED_AUTH_CHAP: u32 = 1 << 2;
+/// MMBearerType: LTE 初始附着承载（default-attach）
+const MM_BEARER_TYPE_DEFAULT_ATTACH: u32 = 2;
+const APN_CONTEXT_TYPE_ATTACH: &str = "attach";
 
 fn bearer_ip_type_to_protocol(v: u32) -> &'static str {
     match v {
@@ -4544,7 +4640,13 @@ pub async fn list_apn_contexts(
             .map(mm_allowed_auth_to_apn_auth_method)
             .unwrap_or("chap");
         let connected = props.get("Connected").map(extract_bool).unwrap_or(false);
-        let name = path.rsplit('/').next().unwrap_or("bearer").to_string();
+        let bearer_type = props.get("Type").map(extract_u32).unwrap_or(0);
+        let is_attach = bearer_type == MM_BEARER_TYPE_DEFAULT_ATTACH;
+        let name = if is_attach {
+            "attach".to_string()
+        } else {
+            path.rsplit('/').next().unwrap_or("bearer").to_string()
+        };
         contexts.push(ApnContext {
             path: path.clone(),
             name,
@@ -4554,7 +4656,11 @@ pub async fn list_apn_contexts(
             username: user,
             password,
             auth_method: auth_method.into(),
-            context_type: "internet".into(),
+            context_type: if is_attach {
+                APN_CONTEXT_TYPE_ATTACH.into()
+            } else {
+                "internet".into()
+            },
         });
     }
     if let Some(config) = configured_apn.filter(|config| !config.apn.trim().is_empty()) {
@@ -4568,6 +4674,7 @@ pub async fn list_apn_contexts(
             }
         }
     }
+    let mut contexts = dedup_apn_contexts(contexts);
     if contexts.is_empty() {
         let mut fallback = configured_apn
             .map(apn_config_to_simple_connect_settings)
@@ -4602,6 +4709,31 @@ pub async fn list_apn_contexts(
         });
     }
     Ok(ApnListResponse { contexts })
+}
+
+/// 去重 APN 上下文：每次拨号会在 ModemManager 中新建 bearer，旧的断开 bearer
+/// 不会被回收，导致同一 APN/协议出现多个重复条目。同键仅保留一个：
+/// 优先已连接者，否则保留最新出现的。附着承载（attach）单独展示，不参与去重。
+fn dedup_apn_contexts(contexts: Vec<ApnContext>) -> Vec<ApnContext> {
+    let mut result: Vec<ApnContext> = Vec::new();
+    for ctx in contexts {
+        if ctx.context_type == APN_CONTEXT_TYPE_ATTACH {
+            result.push(ctx);
+            continue;
+        }
+        let key = (ctx.apn.trim().to_ascii_lowercase(), ctx.protocol.clone());
+        if let Some(existing) = result.iter_mut().find(|c| {
+            c.context_type != APN_CONTEXT_TYPE_ATTACH
+                && (c.apn.trim().to_ascii_lowercase(), c.protocol.clone()) == key
+        }) {
+            if !existing.active {
+                *existing = ctx;
+            }
+        } else {
+            result.push(ctx);
+        }
+    }
+    result
 }
 
 fn extract_object_path_array(value: &OwnedValue) -> Vec<String> {


### PR DESCRIPTION
# fix: SMS storage info on ME-default modems + duplicated APN profiles from stale bearers / 修复 ME 默认存储模组的短信存储信息及重复 APN 配置

[中文](#中文说明) | [English](#english)

---

## 中文说明

### 摘要

针对与原目标设备行为不同的模组，修复 `backend/src/modem_manager.rs` 中的两个问题。
两者均在 Quectel EC20 模组上复现（主端口为 `cdc-wdm0`，无独立 AT 串口），
运行环境为 Debian 13 / ModemManager，驻网运营商 MORE/CSL（454-00）。

### 1. 模组默认短信存储为 `ME` 时，短信存储信息显示错误

**现象：** SIM 卡面板显示的短信存储用量为空或错误。

**根因：** `parse_sms_storage_info()` 只解析 `AT+CPMS?` 回复中的 SIM 卡存储
（`"SM"`）三元组。默认短信存储为模组内存的模组，其回复中只有 `ME` 三元组：

```
AT+CPMS? → +CPMS: "ME",0,255,"ME",0,255,"ME",0,255
```

（可通过 `mmcli -m 0 --messaging-status` 验证 → `default storages: me`）。
解析返回 `None` 后，`sms_storage_cache` 中被写入 `"empty"` 占位行，
且在 ICCID 变化前一直不会重新抓取。

**修复：**

- 解析器仍优先取 `"SM"` 三元组（SIM 存储设备行为不变），否则回退取第一个
  有效存储三元组（如 `"ME"`）。
- 后台刷新流程现在会重试无 total 的缓存条目（`sms_storage_cache_incomplete`）。
  `sim_details_cache_missing` 的自动触发语义有意保持不变：空占位在 ICCID
  变化前不会随每次 `/api/sim` 轮询重复探测，不会引入额外的 AT 探测或
  MM 调试日志切换。

### 2. `/api/apn` 显示重复的 APN 配置

**现象：** APN 选择器列出多个完全相同的条目（相同 APN，"未连接"）。

**根因：** 每次 `nmcli connection up` 都会让 ModemManager 新建一个 bearer 对象，
旧的已断开 bearer 在模组禁用或 MM 重启前不会被回收。`list_apn_contexts()`
将所有已知 bearer（`Bearers` + `InitialBearer`）原样列出，因此在几次重连后
（例如切换漫游开关）列表变成：

| Bearer | 类型 | APN | 已连接 |
|---|---|---|---|
| `/Bearer/0` | `default-attach` | `MORE` | 是 |
| `/Bearer/1` | `default` | `more` | 否（遗留） |
| `/Bearer/2` | `default` | `more` | 否（遗留） |

**修复：**

- 相同 `(APN, 协议)` 的数据承载去重——优先保留已连接者，否则保留最新的
  （`dedup_apn_contexts`）。
- LTE 初始附着承载（`MMBearerType == default-attach`）现在标记为
  `name: "attach"` / `context_type: "attach"`，不再作为无法区分的数字条目出现。
- API 响应结构不变（`ApnContext` 字段未改动），现有前端可直接渲染。

### 测试

- 新增 7 个单元测试：仅 `ME` 回退、`SM` 优先、异常输入拒绝、遗留 bearer 去重、
  已连接 bearer 优先、不同 APN 保留。
- 更新 1 个既有断言（`+CPMS: "ME",5,50` ⇒ 现在为 `Some((5, 50))`）；
  该断言此前锁定的是有缺陷的 `None` 行为。
- 全量测试：**105 通过，0 失败**。
- 已在受影响设备上部署验证：短信存储可从实际 `+CPMS: "ME",...` 回复中正确解析，
  APN 列表显示 `attach (MORE)` + 一个数据配置，而非三个条目。

---

## English

### Summary

Two fixes in `backend/src/modem_manager.rs` for modems that behave differently
from the original target device. Both were observed on a 
Quectel EC20 modem (primary port `cdc-wdm0`, no separate AT tty) running on Debian 13 /
ModemManager, registered on MORE/CSL (454-00).

### 1. SMS storage info is wrong when the modem's default storage is `ME`

**Symptom:** the SIM panel shows empty/wrong SMS storage usage.

**Root cause:** `parse_sms_storage_info()` only accepted the SIM storage
(`"SM"`) triple in the `AT+CPMS?` reply. Modems whose default SMS storage is
modem memory reply with `ME` triples only:

```
AT+CPMS? → +CPMS: "ME",0,255,"ME",0,255,"ME",0,255
```

(verifiable with `mmcli -m 0 --messaging-status` → `default storages: me`).
Parsing returned `None`, and an `"empty"` placeholder row was cached in
`sms_storage_cache`, which then stuck until the ICCID changed.

**Fix:**

- The parser still prefers the `"SM"` triple when present (no behavior change
  on SIM-storage devices), but falls back to the first valid storage triple
  (e.g. `"ME"`) otherwise.
- Background refreshes now retry storage entries that were cached without a
  total (`sms_storage_cache_incomplete`). The auto-trigger semantics of
  `sim_details_cache_missing` are deliberately unchanged: empty placeholders
  still don't re-probe on every `/api/sim` poll until the ICCID changes, so
  no extra AT probing / MM debug-logging toggles are introduced.

### 2. `/api/apn` shows duplicated APN profiles

**Symptom:** the APN selector lists several identical entries (same APN,
"未连接" / not connected).

**Root cause:** each `nmcli connection up` makes ModemManager create a *new*
bearer object, and stale disconnected bearers are not garbage-collected until
the modem is disabled or MM restarts. `list_apn_contexts()` listed every known
bearer (`Bearers` + `InitialBearer`) verbatim, so after a few reconnects (e.g.
toggling roaming) the list looked like:

| Bearer | Type | APN | Connected |
|---|---|---|---|
| `/Bearer/0` | `default-attach` | `MORE` | yes |
| `/Bearer/1` | `default` | `more` | no (stale) |
| `/Bearer/2` | `default` | `more` | no (stale) |

**Fix:**

- Data bearers with the same `(APN, protocol)` are deduplicated — the
  connected bearer wins, otherwise the newest is kept (`dedup_apn_contexts`).
- The LTE initial attach bearer (`MMBearerType == default-attach`) is now
  labeled `name: "attach"` / `context_type: "attach"` instead of appearing as
  another indistinguishable numeric entry.
- The API response shape is unchanged (`ApnContext` fields untouched), so the
  existing frontend renders it as-is.

### Testing

- 7 new unit tests: `ME`-only fallback, `SM` preference, garbage rejection,
  stale-bearer dedup, connected-bearer preference, distinct-APN preservation.
- One existing assertion updated (`+CPMS: "ME",5,50` ⇒ now `Some((5, 50))`);
  it previously asserted the buggy `None` behavior.
- Full suite: **105 passed, 0 failed**.
- Deployed on the affected device: SMS storage now parses from the live
  `+CPMS: "ME",...` reply, and the APN list shows `attach (MORE)` + one data
  profile instead of three entries.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
