### PR TITLE
feat: add x86_64 support with lpac compatibility

### DIFF
--- a/.github/workflows/build-lpac-compat.yml
+++ b/.github/workflows/build-lpac-compat.yml
@@ -1,16 +1,15 @@
-name: Build-Lpac-Compat
+name: Build lpac compatibility bundles
 
-# 从 lpac 官方源码编译兼容老版本 glibc (2.31) 的 aarch64 二进制。
-# 产物上传到 GitHub Release (固定标签为 lpac)，供安装脚本和后端一键修复功能使用。
+# Build self-contained lpac bundles for the oldest supported glibc baseline.
+# They ship their own libqmi, avoiding a host libqmi ABI dependency.
 
 on:
   schedule:
-    # 每天凌晨 0:00 自动检查官方是否有更新
     - cron: '0 0 5,20 * *'
   workflow_dispatch:
     inputs:
       lpac_ref:
-        description: '手动指定官方构建的分支或 Tag (例如: v2.3.0, main)'
+        description: 'Official lpac branch, tag, or commit (for example: v2.3.0)'
         required: false
         type: string
         default: ''
@@ -19,201 +18,203 @@ permissions:
   contents: write
 
 jobs:
-  build-lpac-compat:
-    name: Build lpac (glibc 2.31, aarch64)
-    runs-on: ubuntu-24.04-arm
-
+  prepare:
+    name: Resolve lpac source
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+      lpac_ref: ${{ steps.check.outputs.lpac_ref }}
+      compat_revision: ${{ steps.check.outputs.compat_revision }}
     steps:
-      - name: Checkout SimAdmin (for workflow context)
-        uses: actions/checkout@v4
-
-      - name: Check for lpac updates
+      - name: Check whether compatibility assets need rebuilding
         id: check
+        env:
+          MANUAL_REF: ${{ inputs.lpac_ref }}
+          CURRENT_REPOSITORY: ${{ github.repository }}
+          COMPAT_REVISION: "2"
         run: |
-          # 1. 获取官方最新 release tag
-          OFFICIAL_TAG=$(curl -s https://api.github.com/repos/estkme-group/lpac/releases/latest | jq -r .tag_name)
-          echo "Official latest lpac tag: $OFFICIAL_TAG"
-          
-          # 2. 如果输入了手动参数，以手动参数为准
-          MANUAL_REF="${{ github.event.inputs.lpac_ref }}"
-          if [ -n "$MANUAL_REF" ]; then
-            echo "Using manually specified ref: $MANUAL_REF"
-            echo "should_build=true" >> $GITHUB_OUTPUT
-            echo "lpac_ref=$MANUAL_REF" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          
-          # 3. 读取我们当前打包的版本 (从我们仓库 releases/download/lpac/lpac.json)
-          OUR_MANIFEST=$(curl -sL -f https://github.com/3899/SimAdmin/releases/download/lpac/lpac.json || echo "{}")
-          OUR_TAG=$(echo "$OUR_MANIFEST" | jq -r '.version // empty' || echo "")
-          echo "Our current compiled lpac tag: $OUR_TAG"
-          
-          if [ "$OFFICIAL_TAG" = "$OUR_TAG" ] && [ -n "$OUR_TAG" ]; then
-            echo "No new updates found. Skipping build."
-            echo "should_build=false" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          official_tag="$(curl -fsSL https://api.github.com/repos/estkme-group/lpac/releases/latest | jq -r .tag_name)"
+          lpac_ref="${MANUAL_REF:-$official_tag}"
+          manifest="$(curl -fsSL "https://github.com/${CURRENT_REPOSITORY}/releases/download/lpac/lpac.json" || printf '{}')"
+          bundled_version="$(printf '%s' "$manifest" | jq -r '.version // empty')"
+          bundled_revision="$(printf '%s' "$manifest" | jq -r '.compat_revision // empty')"
+          has_all_assets="$(printf '%s' "$manifest" | jq -r '
+            [.assets[]?.name] as $assets
+            | (["lpac-linux-aarch64-glibc2.31.zip", "lpac-linux-x86_64-glibc2.31.zip"]
+              | all(. as $name | $assets | index($name)))
+          ' 2>/dev/null || printf false)"
+
+          echo "lpac_ref=$lpac_ref" >> "$GITHUB_OUTPUT"
+          echo "compat_revision=$COMPAT_REVISION" >> "$GITHUB_OUTPUT"
+          if [ "$MANUAL_REF" = "" ] \
+            && [ "$bundled_version" = "$official_tag" ] \
+            && [ "$bundled_revision" = "$COMPAT_REVISION" ] \
+            && [ "$has_all_assets" = "true" ]; then
+            echo "Compatibility bundles already match $official_tag."
+            echo 'should_build=false' >> "$GITHUB_OUTPUT"
           else
-            echo "New version detected ($OFFICIAL_TAG) or our release is missing. Building..."
-            echo "should_build=true" >> $GITHUB_OUTPUT
-            echo "lpac_ref=$OFFICIAL_TAG" >> $GITHUB_OUTPUT
+            echo "Building compatibility bundles from $lpac_ref."
+            echo 'should_build=true' >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build lpac inside Debian 11 container
-        if: steps.check.outputs.should_build == 'true'
+  build:
+    name: Build ${{ matrix.arch }} compatibility bundle
+    needs: prepare
+    if: needs.prepare.outputs.should_build == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            asset: lpac-linux-aarch64-glibc2.31.zip
+          - arch: x86_64
+            runner: ubuntu-latest
+            asset: lpac-linux-x86_64-glibc2.31.zip
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Build lpac with bundled libqmi in Debian 11
+        env:
+          LPAC_REF: ${{ needs.prepare.outputs.lpac_ref }}
+          ASSET_NAME: ${{ matrix.asset }}
+          COMPAT_REVISION: ${{ needs.prepare.outputs.compat_revision }}
         run: |
+          set -euo pipefail
           mkdir -p release
           docker run --rm \
+            -e LPAC_REF -e ASSET_NAME -e COMPAT_REVISION \
             -v "$GITHUB_WORKSPACE/release:/output" \
             debian:11 bash -c '
               set -eux
 
               apt-get update
               apt-get install -y --no-install-recommends \
-                build-essential cmake git ca-certificates zip \
+                build-essential binutils cmake git ca-certificates zip \
                 pkg-config python3 python3-pip ninja-build \
                 libcurl4-openssl-dev libglib2.0-dev \
                 libpcsclite-dev libgudev-1.0-dev libglib2.0-doc \
                 libudev-dev udev
-
-              # Debian 11 自带的 meson 太老，通过 pip 安装新版
               pip3 install meson
 
-              # ── 第一步：从源码编译 libqmi (Debian 11 自带版本 1.26 太老，lpac 要求 >=1.35) ──
-              echo ">>> Building libqmi from source..."
-              git clone --depth 1 --branch 1.36.0 https://gitlab.freedesktop.org/mobile-broadband/libqmi.git /libqmi-src
-              cd /libqmi-src
-              meson setup build \
-                --prefix=/usr/local \
-                --libdir=lib \
-                --buildtype=release \
-                -Dcollection=full \
-                -Dmbim_qmux=false \
-                -Dqrtr=false \
-                -Dintrospection=false \
-                -Dman=false \
-                -Dbash_completion=false \
+              git clone --depth 1 --branch 1.36.0 \
+                https://gitlab.freedesktop.org/mobile-broadband/libqmi.git /libqmi-src
+              meson setup /libqmi-src/build /libqmi-src \
+                --prefix=/usr/local --libdir=lib --buildtype=release \
+                -Dcollection=full -Dmbim_qmux=false -Dqrtr=false \
+                -Dintrospection=false -Dman=false -Dbash_completion=false \
                 -Dqmi_username=root
-              ninja -C build
-              ninja -C build install
+              ninja -C /libqmi-src/build
+              ninja -C /libqmi-src/build install
               ldconfig
-              echo ">>> libqmi installed: $(pkg-config --modversion qmi-glib)"
 
-              # ── 第二步：编译 lpac ──
-              git clone --depth 1 --branch "$0" https://github.com/estkme-group/lpac /lpac
-              cd /lpac
+              git clone --depth 1 --branch "$LPAC_REF" \
+                https://github.com/estkme-group/lpac /lpac
+              cmake -S /lpac -B /lpac/build \
+                -DCMAKE_BUILD_TYPE=Release -DSTANDALONE_MODE=ON \
+                -DLPAC_WITH_APDU_PCSC=OFF -DLPAC_WITH_APDU_AT=ON \
+                -DLPAC_WITH_APDU_QMI=ON \
+                -DCMAKE_INSTALL_RPATH="\$ORIGIN/lib"
+              cmake --build /lpac/build --parallel
+              DESTDIR=/tmp/lpac-install cmake --install /lpac/build
 
-              # 解析出实际编译版本
-              RESOLVED_VER=$(git describe --tags --always || git rev-parse --short HEAD || echo "$0")
-              echo "$RESOLVED_VER" > /output/resolved_version.txt
+              bundle=/tmp/lpac-bundle
+              mkdir -p "$bundle/lib"
+              lpac_bin="$(find /tmp/lpac-install -type f -name lpac -print -quit)"
+              test -n "$lpac_bin"
+              install -m 0755 "$lpac_bin" "$bundle/lpac"
 
-              mkdir build && cd build
-              cmake .. \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DSTANDALONE_MODE=ON \
-                -DLPAC_WITH_APDU_PCSC=OFF \
-                -DLPAC_WITH_APDU_AT=ON \
-                -DLPAC_WITH_APDU_QMI=ON
-              make -j$(nproc)
+              qmi_so="$(find /usr/local/lib -type f -name "libqmi-glib.so.*.*.*" -print -quit)"
+              test -n "$qmi_so"
+              cp -L "$qmi_so" "$bundle/lib/"
+              qmi_basename="$(basename "$qmi_so")"
+              ln -s "$qmi_basename" "$bundle/lib/libqmi-glib.so.5"
+              ln -s "$qmi_basename" "$bundle/lib/libqmi-glib.so"
+              printf "%s\n" "$COMPAT_REVISION" > "$bundle/COMPAT_REVISION.txt"
 
-              # 安装到临时目录 (STANDALONE_MODE 输出到 executables/)
-              DESTDIR=/tmp/lpac-install cmake --install .
+              readelf -d "$bundle/lpac" | grep -E "\(RPATH\)|\(RUNPATH\)" | grep -F ORIGIN/lib
+              ldd "$bundle/lpac" | grep -F "$bundle/lib/libqmi-glib.so.5"
+              LPAC_APDU=stdio LPAC_HTTP=stdio "$bundle/lpac" driver list \
+                | tee /tmp/lpac-drivers.json
+              grep -Fq qmi /tmp/lpac-drivers.json
+              grep -Fq curl /tmp/lpac-drivers.json
 
-              # 创建打包目录
-              BUNDLE_ROOT="/tmp/lpac-bundle"
-              mkdir -p "$BUNDLE_ROOT"
+              cd "$bundle"
+              zip -qr "/output/$ASSET_NAME" .
+              chmod 0644 "/output/$ASSET_NAME"
+            '
 
-              # 动态查找编译并安装好的 lpac 二进制文件
-              LPAC_BIN=$(find /tmp/lpac-install -name lpac -type f | head -1)
-              if [ -z "$LPAC_BIN" ] || [ ! -f "$LPAC_BIN" ]; then
-                echo "ERROR: lpac binary not found in /tmp/lpac-install"
-                ls -laR /tmp/lpac-install/ || true
-                exit 1
-              fi
-              cp "$LPAC_BIN" "$BUNDLE_ROOT/lpac"
-              chmod 755 "$BUNDLE_ROOT/lpac"
-
-              # 将自编译的 libqmi-glib.so 复制到 lib/ 目录中，使 zip 包自包含
-              mkdir -p "$BUNDLE_ROOT/lib"
-              QMI_SO=$(find /usr/local/lib -name "libqmi-glib.so.*.*.*" -type f | head -1)
-              if [ -n "$QMI_SO" ]; then
-                cp -L "$QMI_SO" "$BUNDLE_ROOT/lib/"
-                QMI_BASENAME=$(basename "$QMI_SO")
-                ln -sf "$QMI_BASENAME" "$BUNDLE_ROOT/lib/libqmi-glib.so.5"
-                ln -sf "$QMI_BASENAME" "$BUNDLE_ROOT/lib/libqmi-glib.so"
-              fi
-
-              # 验证
-              echo "=== Bundle contents ==="
-              ls -laR "$BUNDLE_ROOT"
-              ldd "$BUNDLE_ROOT/lpac" || true
-
-              # 打包
-              cd "$BUNDLE_ROOT"
-              zip -r /output/lpac-linux-aarch64-glibc2.31.zip .
-
-              # 改变输出目录下的权限，防止主机 runner 权限不足
-              chmod -R 777 /output
-              echo "✅ Build complete"
-            ' "${{ steps.check.outputs.lpac_ref }}"
-
-      - name: Verify output
-        if: steps.check.outputs.should_build == 'true'
+      - name: Verify bundle contents
         run: |
-          ls -lh release/
-          file release/lpac-linux-aarch64-glibc2.31.zip
+          set -euo pipefail
+          unzip -l "release/${{ matrix.asset }}"
+          unzip -p "release/${{ matrix.asset }}" lpac >/dev/null
 
-      - name: Resolve version info
-        id: resolve_ver
-        if: steps.check.outputs.should_build == 'true'
-        run: |
-          LPAC_VER=$(cat release/resolved_version.txt)
-          echo "lpac_ver=$LPAC_VER" >> $GITHUB_OUTPUT
+      - name: Upload compatibility bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: lpac-${{ matrix.arch }}
+          path: release/${{ matrix.asset }}
+          if-no-files-found: error
 
-      - name: Generate lpac.json manifest
-        if: steps.check.outputs.should_build == 'true'
+  publish:
+    name: Publish lpac compatibility assets
+    needs: [prepare, build]
+    if: needs.prepare.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download bundles
+        uses: actions/download-artifact@v4
+        with:
+          pattern: lpac-*
+          path: release
+          merge-multiple: true
+
+      - name: Generate manifest and checksums
+        env:
+          LPAC_REF: ${{ needs.prepare.outputs.lpac_ref }}
+          COMPAT_REVISION: ${{ needs.prepare.outputs.compat_revision }}
         run: |
-          cat > release/lpac.json << MANIFEST
+          set -euo pipefail
+          test -f release/lpac-linux-aarch64-glibc2.31.zip
+          test -f release/lpac-linux-x86_64-glibc2.31.zip
+          sha256sum release/lpac-linux-*.zip > release/SHA256SUMS
+          cat > release/lpac.json <<EOF
           {
-            "version": "${{ steps.resolve_ver.outputs.lpac_ver }}",
+            "version": "${LPAC_REF}",
+            "compat_revision": "${COMPAT_REVISION}",
             "assets": [
               {
                 "name": "lpac-linux-aarch64-glibc2.31.zip",
                 "arch": "aarch64",
                 "glibc": "2.31",
-                "description": "lpac for aarch64 built against glibc 2.31 (Debian 11)"
+                "description": "lpac with bundled libqmi for aarch64"
+              },
+              {
+                "name": "lpac-linux-x86_64-glibc2.31.zip",
+                "arch": "x86_64",
+                "glibc": "2.31",
+                "description": "lpac with bundled libqmi for x86_64"
               }
             ]
           }
-          MANIFEST
+          EOF
+          jq -e . release/lpac.json
 
-      - name: Upload to SimAdmin Release
-        if: steps.check.outputs.should_build == 'true'
+      - name: Publish to the compatibility release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: lpac
-          name: eSIM lpac Compatibility Assets
+          name: eSIM lpac compatibility assets
           body: |
-            eSIM lpac compatibility assets for legacy device environments:
-            * **lpac Source**: `estkme-group/lpac@${{ steps.resolve_ver.outputs.lpac_ver }}`
-            * **Glibc version**: `2.31` (Debian 11)
-            * **Architecture**: `aarch64` (ARM64)
+            Self-contained lpac builds with bundled libqmi for ARM64 and x86_64.
+            Source: `estkme-group/lpac@${{ needs.prepare.outputs.lpac_ref }}`
           draft: false
-          prerelease: true # 标记为预发布版，防止其成为最新版
-          make_latest: false # ⚠️ 重要：请勿修改为 true！此 workflow 仅打包兼容版 lpac 静态资源，非项目主版本 Release，决不能发布为 Latest。
+          prerelease: true
+          make_latest: false
           files: |
-            release/lpac-linux-aarch64-glibc2.31.zip
+            release/lpac-linux-*.zip
             release/lpac.json
-          overwrite_files: true
+            release/SHA256SUMS
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Summary
-        if: steps.check.outputs.should_build == 'true'
-        run: |
-          echo "## 🎉 lpac compat build complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Item | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| lpac source | estkme-group/lpac@${{ steps.resolve_ver.outputs.lpac_ver }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Target glibc | 2.31 (Debian 11) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Architecture | aarch64 (native ARM64 runner) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Attached to Release | lpac |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-ota-package.yml
+++ b/.github/workflows/build-ota-package.yml
@@ -30,335 +30,214 @@ permissions:
   contents: write
 
 jobs:
-  build-ota:
-    name: Build OTA Package
-    runs-on: ubuntu-24.04-arm
-    
+  prepare:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      current_version: ${{ steps.version.outputs.current_version }}
+      version_source: ${{ steps.version.outputs.version_source }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # 获取完整历史，用于 git commit hash
-      
+      - uses: actions/checkout@v4
+      - name: Validate installer
+        run: |
+          sh -n install_latest.sh
+          sh -n tests/install_latest_test.sh
+          tests/install_latest_test.sh
       - name: Read VERSION
         id: version
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          CURRENT_VERSION=$(cat VERSION | tr -d '[:space:]')
-          VERSION=$(echo "$INPUT_VERSION" | tr -d '[:space:]')
-
+          CURRENT_VERSION=$(tr -d '[:space:]' < VERSION)
+          VERSION=$(printf '%s' "$INPUT_VERSION" | tr -d '[:space:]')
           if [ -z "$VERSION" ] || [ "$VERSION" = "auto" ]; then
             VERSION="$CURRENT_VERSION"
             SOURCE="VERSION file"
           else
             SOURCE="workflow input"
           fi
-
-          if [ -z "$VERSION" ]; then
-            echo "❌ 错误: 版本号不能为空"
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){1,3}([-.][0-9A-Za-z]+)*$'; then
+            echo "Invalid version: $VERSION" >&2
             exit 1
           fi
+          {
+            echo "version=$VERSION"
+            echo "current_version=$CURRENT_VERSION"
+            echo "version_source=$SOURCE"
+          } >> "$GITHUB_OUTPUT"
 
-          if ! echo "$VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){1,3}([-.][0-9A-Za-z]+)*$'; then
-            echo "❌ 错误: 版本号格式不合法: $VERSION"
-            echo "示例: 1.0.0, 1.0.0-beta.1"
-            exit 1
-          fi
+  build:
+    name: Build ${{ matrix.target }}
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-          echo "version_source=$SOURCE" >> $GITHUB_OUTPUT
-          echo "📦 当前 VERSION 文件版本: $CURRENT_VERSION"
-          echo "📦 本次打包版本号: $VERSION ($SOURCE)"
-      
-      # ==================== 安装 Rust 工具链 ====================
+      - name: Sync version numbers
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          printf '%s\n' "$VERSION" > VERSION
+          sed -i "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" backend/Cargo.toml
+          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" frontend/package.json
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-unknown-linux-musl
-      
-      # ==================== 安装交叉编译工具链 ====================
-      - name: Install cross-compilation toolchain
+          targets: ${{ matrix.target }}
+
+      - name: Install native build tools
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
+          if [ "${{ inputs.use_upx }}" = "true" ]; then
+            sudo apt-get install -y upx-ucl
+          fi
           musl-gcc --version
-      
-      # ==================== 安装 UPX (可选) ====================
-      - name: Install UPX
-        if: inputs.use_upx == true
-        run: |
-          sudo apt-get install -y upx-ucl
-          upx --version
-      
-      # ==================== 缓存 Rust 依赖 ====================
+
       - name: Cache Rust dependencies
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             backend/target/
-          key: ${{ runner.os }}-musl-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-musl-cargo-
-      
-      # ==================== 同步版本号 ====================
-      - name: Sync version numbers
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          echo "同步版本号: $VERSION"
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-${{ hashFiles('backend/Cargo.lock') }}
 
-          # 更新根目录 VERSION，确保 build.rs 注入的 APP_VERSION 与本次 OTA 包一致
-          printf "%s\n" "$VERSION" > VERSION
-          
-          # 更新 backend/Cargo.toml
-          sed -i "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" backend/Cargo.toml
-          
-          # 更新 frontend/package.json
-          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" frontend/package.json
-          
-          echo "✅ 版本号同步完成"
-      
-      # ==================== 构建后端 ====================
-      - name: Build backend (aarch64-unknown-linux-musl)
+      - name: Build backend
         working-directory: backend
+        env:
+          TARGET: ${{ matrix.target }}
+          SQLITE3_STATIC: '1'
+          LIBSQLITE3_SYS_USE_PKG_CONFIG: '0'
         run: |
-          echo "🦀 构建后端 (aarch64-unknown-linux-musl)..."
-          
-          # 设置交叉编译环境变量
-          export CC_AARCH64_UNKNOWN_LINUX_MUSL=musl-gcc
-          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
-          export SQLITE3_STATIC=1
-          export LIBSQLITE3_SYS_USE_PKG_CONFIG=0
-          
-          # 构建
-          cargo build --release --target aarch64-unknown-linux-musl
-          
-          BINARY_PATH="target/aarch64-unknown-linux-musl/release/simadmin"
-          
-          echo "✅ 后端构建完成！"
-          ls -lh "$BINARY_PATH"
-          file "$BINARY_PATH"
-      
-      # ==================== UPX 压缩 (可选) ====================
-      - name: Compress binary with UPX
+          case "$TARGET" in
+            aarch64-unknown-linux-musl)
+              export CC_aarch64_unknown_linux_musl=musl-gcc
+              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+              ;;
+            x86_64-unknown-linux-musl)
+              export CC_x86_64_unknown_linux_musl=musl-gcc
+              export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+              ;;
+          esac
+          cargo build --locked --release --target "$TARGET"
+          file "target/$TARGET/release/simadmin"
+
+      - name: Compress backend with UPX
         if: inputs.use_upx == true
-        run: |
-          BINARY_PATH="backend/target/aarch64-unknown-linux-musl/release/simadmin"
-          
-          echo "🗜️  UPX 压缩中..."
-          BEFORE_SIZE=$(stat -c%s "$BINARY_PATH")
-          
-          upx --best --lzma "$BINARY_PATH"
-          
-          AFTER_SIZE=$(stat -c%s "$BINARY_PATH")
-          RATIO=$(echo "scale=1; 100 - ($AFTER_SIZE * 100 / $BEFORE_SIZE)" | bc)
-          
-          echo "✅ 压缩完成！节省: ${RATIO}%"
-          ls -lh "$BINARY_PATH"
-      
-      # ==================== 设置 Node.js 环境 ====================
+        env:
+          TARGET: ${{ matrix.target }}
+        run: upx --best --lzma "backend/target/$TARGET/release/simadmin"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-      
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
-      
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-      
-      # ==================== 构建前端 ====================
+
       - name: Build frontend
         working-directory: frontend
         run: |
-          echo "🎨 构建前端..."
           pnpm install --frozen-lockfile
-          pnpm run build
-          
-          echo "✅ 前端构建完成！"
-          ls -lh dist/
-      
-      # ==================== 打包 OTA ====================
-      - name: Package OTA
-        run: |
-          echo "=========================================="
-          echo "  生成 OTA 更新包"
-          echo "=========================================="
-          echo ""
-          
-          VERSION="${{ steps.version.outputs.version }}"
-          COMMIT=$(git rev-parse --short HEAD)
-          BUILD_TIME=$(TZ=Asia/Shanghai date +"%Y-%m-%dT%H:%M:%S+08:00")
-          ARCH="aarch64-unknown-linux-musl"
-          
-          BINARY_PATH="backend/target/aarch64-unknown-linux-musl/release/simadmin"
-          FRONTEND_DIR="frontend/dist"
-          
-          # 检查构建产物
-          if [ ! -f "$BINARY_PATH" ]; then
-            echo "❌ 错误: 后端二进制不存在"
-            exit 1
-          fi
-          
-          if [ ! -d "$FRONTEND_DIR" ]; then
-            echo "❌ 错误: 前端构建产物不存在"
-            exit 1
-          fi
-          
-          # 创建临时目录
-          OTA_TMP=$(mktemp -d)
-          
-          echo "📦 版本: $VERSION"
-          echo "📝 Commit: $COMMIT"
-          echo "🕐 构建时间: $BUILD_TIME"
-          echo "📍 架构: $ARCH"
-          echo ""
-          
-          # 复制后端二进制
-          echo "📋 复制后端二进制..."
-          cp "$BINARY_PATH" "$OTA_TMP/simadmin"
-          chmod 755 "$OTA_TMP/simadmin"
-          
-          # 计算二进制 MD5 (Linux)
-          BINARY_MD5=$(md5sum "$OTA_TMP/simadmin" | cut -d' ' -f1)
-          echo "   MD5: $BINARY_MD5"
-          
-          # 复制前端文件
-          echo "📋 复制前端文件..."
-          mkdir -p "$OTA_TMP/www"
-          cp -r "$FRONTEND_DIR"/* "$OTA_TMP/www/"
+          pnpm run lint
+          pnpm exec vite build
 
-          # 计算前端 MD5 (Linux)
-          echo "📋 计算前端 MD5..."
-          FRONTEND_MD5=$(find "$OTA_TMP/www" -type f -exec md5sum {} \; | cut -d' ' -f1 | sort | md5sum | cut -d' ' -f1)
-          echo "   MD5: $FRONTEND_MD5"
-          
-          # 生成 meta.json
-          echo "📋 生成 meta.json..."
-          cat > "$OTA_TMP/meta.json" << EOF
+      - name: Package OTA
+        env:
+          TARGET: ${{ matrix.target }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          ./scripts/pack-ota.sh --target="$TARGET"
+          SOURCE="release/simadmin_${VERSION}_${TARGET}.tar.gz"
+          DEST="release/simadmin-${TARGET}.tar.gz"
+          mv "$SOURCE" "$DEST"
+          if [ "$TARGET" = "aarch64-unknown-linux-musl" ]; then
+            cp "$DEST" release/simadmin.tar.gz
+          fi
+          sha256sum release/*.tar.gz
+
+      - name: Upload OTA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ota-${{ matrix.target }}
+          path: release/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Publish release
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download OTA artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ota-*
+          path: release
+          merge-multiple: true
+
+      - name: Generate checksums and release notes
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          cd release
+          sha256sum -- ./*.tar.gz > SHA256SUMS
           {
-              "version": "$VERSION",
-              "commit": "$COMMIT",
-              "build_time": "$BUILD_TIME",
-              "binary_md5": "$BINARY_MD5",
-              "frontend_md5": "$FRONTEND_MD5",
-              "arch": "$ARCH"
-          }
-          EOF
-          
-          cat "$OTA_TMP/meta.json"
-          echo ""
-          
-          # 创建输出目录
-          mkdir -p release
-          
-          # 打包
-          OTA_FILE="release/simadmin.tar.gz"
-          echo "📦 打包 OTA 更新包..."
-          cd "$OTA_TMP"
-          tar -czf "$GITHUB_WORKSPACE/$OTA_FILE" meta.json simadmin www
-          cd "$GITHUB_WORKSPACE"
-          
-          # 显示结果
-          echo ""
-          echo "=========================================="
-          echo "✅ OTA 更新包打包完成！"
-          echo "=========================================="
-          echo ""
-          echo "📍 输出文件: $OTA_FILE"
-          ls -lh "$OTA_FILE"
-          echo ""
-          echo "📋 包内容:"
-          tar -tzf "$OTA_FILE" | head -20
-          echo ""
-          
-          # 计算包的 MD5 和 SHA-256
-          OTA_MD5=$(md5sum "$OTA_FILE" | cut -d' ' -f1)
-          OTA_SHA256=$(sha256sum "$OTA_FILE" | cut -d' ' -f1)
-          echo "📝 OTA 包 MD5: $OTA_MD5"
-          echo "📝 OTA 包 SHA-256: $OTA_SHA256"
-          echo ""
-          
-          # 保存到输出
-          echo "ota_file=$OTA_FILE" >> $GITHUB_OUTPUT
-          echo "ota_md5=$OTA_MD5" >> $GITHUB_OUTPUT
-          echo "ota_sha256=$OTA_SHA256" >> $GITHUB_OUTPUT
-          echo "build_time=$BUILD_TIME" >> $GITHUB_OUTPUT
-        id: package
-      
-      # ==================== 发布 OTA 包为 Release Asset ====================
-      - name: Publish OTA package
+            echo '## OTA 更新包'
+            echo
+            echo "版本: $VERSION"
+            echo
+            echo "- \`simadmin-aarch64-unknown-linux-musl.tar.gz\`: ARM64"
+            echo "- \`simadmin-x86_64-unknown-linux-musl.tar.gz\`: x86_64 / AMD64"
+            echo "- \`simadmin.tar.gz\`: ARM64 兼容别名"
+            echo
+            echo '安装脚本会自动选择与设备匹配的架构。'
+            echo
+            echo '### SHA-256'
+            echo "\`\`\`text"
+            cat SHA256SUMS
+            echo "\`\`\`"
+          } > RELEASE_BODY.md
+
+      - name: Publish OTA packages
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: SimAdmin_v${{ steps.version.outputs.version }}
-          files: |
-            release/simadmin.tar.gz
+          tag_name: v${{ needs.prepare.outputs.version }}
+          name: SimAdmin_v${{ needs.prepare.outputs.version }}
+          files: release/*.tar.gz
+          body_path: release/RELEASE_BODY.md
           overwrite_files: true
           generate_release_notes: true
-          body: |
-            ## OTA 更新包
-            
-            ### 版本信息
-            
-            - **版本**: ${{ steps.version.outputs.version }}
-            - **Commit**: ${{ github.sha }}
-            - **构建时间**: ${{ steps.package.outputs.build_time }}
-            - **发布类型**: ${{ inputs.release_type }}
-            - **文件名**: `simadmin.tar.gz`
-            - **MD5**: `${{ steps.package.outputs.ota_md5 }}`
-            - **SHA-256**: `${{ steps.package.outputs.ota_sha256 }}`
-            
-            ### 安装说明
-            
-            ```bash
-            # 上传 OTA 包到设备
-            curl -X POST http://IP:3000/api/ota/upload \
-              -F "file=@simadmin.tar.gz"
-            
-            # 开始 OTA 更新
-            curl -X POST http://IP:3000/api/ota/apply
-            ```
           draft: false
           prerelease: ${{ inputs.release_type == '预发布版（pre-release）' }}
           make_latest: ${{ inputs.release_type == '最新正式版（latest release）' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      # ==================== 构建摘要 ====================
-      - name: Build Summary
+
+      - name: Build summary
         run: |
-          echo "## 🎉 OTA 包构建完成" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| 项目 | 值 |" >> $GITHUB_STEP_SUMMARY
-          echo "|------|-----|" >> $GITHUB_STEP_SUMMARY
-          echo "| VERSION 文件版本 | ${{ steps.version.outputs.current_version }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| 版本 | ${{ steps.version.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| 版本来源 | ${{ steps.version.outputs.version_source }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| 发布类型 | ${{ inputs.release_type }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Commit | ${{ github.sha }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| 架构 | aarch64-unknown-linux-musl |" >> $GITHUB_STEP_SUMMARY
-          echo "| UPX 压缩 | ${{ inputs.use_upx }} |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📦 产物" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ steps.package.outputs.ota_file }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- MD5: \`${{ steps.package.outputs.ota_md5 }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- SHA-256: \`${{ steps.package.outputs.ota_sha256 }}\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo '## OTA 多架构构建完成'
+            echo
+            echo '- aarch64-unknown-linux-musl'
+            echo '- x86_64-unknown-linux-musl'
+            echo
+            cat release/SHA256SUMS
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ SimAdmin 是一套面向 Debian 蜂窝 CPE、随身 WiFi、软路由类设备的
 - 后端：Rust + Axum + zbus，主要通过 ModemManager D-Bus 接口管理 modem，并在部分场景使用 `mmcli`、`qmicli` 或 AT 直连兜底。
 - 前端：React + Vite + Material UI，提供仪表盘、SIM 卡管理、蜂窝网络、设备网络、短信管理、通知中心、自动化中心和 OTA 更新页面。
 - 部署形态：后端二进制同进程托管前端 SPA，默认安装到 `/opt/simadmin`，通过 systemd 运行。
+- 发布架构：提供 `aarch64-unknown-linux-musl` 与 `x86_64-unknown-linux-musl` 两种静态构建，安装脚本会按设备架构选择。
 
 健康检查整体按支持 ModemManager 的 Linux 蜂窝设备组织，不同 modem 固件、内核、ModemManager 版本暴露的能力不同，具体功能以实际设备为准。
 
@@ -179,7 +180,7 @@ SimAdmin 是一套面向 Debian 蜂窝 CPE、随身 WiFi、软路由类设备的
 - 基带重启流程和进度查询。
 - 数据连接 watchdog，每 15 秒检查连接状态、iptables 规则数量和 modem 可用性；检测到宿主机防火墙规则时仅记录诊断日志，不自动清空规则。
 - ModemManager 丢失时触发 `mmcli --scan-modems`，连续失败后重启 ModemManager。
-- NetworkManager `wwan*` unmanaged 配置。
+- 安装时补齐并启动 ModemManager / NetworkManager，清理历史 `wwan*` unmanaged 配置，并重新触发 udev modem 候选识别。
 - 设备侧 WLAN 客户端连接管理，通过 NetworkManager/nmcli 扫描和连接无线局域网，WLAN 在线时优先作为设备默认出口。
 - 原生 DDNS 同步，支持腾讯云 DNSPod、阿里云 AliDNS 和 Cloudflare，支持 IPv4/IPv6 独立配置、API/网卡取 IP 和变更/失败事件通知；默认通过网卡取 IP，可切换为内置多接口 API fallback。
 - 短信发送、接收监听、SQLite 持久化和多渠道通知转发。
@@ -189,7 +190,7 @@ SimAdmin 是一套面向 Debian 蜂窝 CPE、随身 WiFi、软路由类设备的
 - APN 列表读取和 APN 修改。
 - 运营商列表、扫描、手动注册、自动注册。
 - eSIM 模式下按需调用 `lpac` 管理实体 eUICC SIM 卡 Profiles；普通 SIM 模式下不调用 eSIM 能力。
-- 安装脚本按设备架构自动准备私有 `lpac`；OTA 包本身不绑定 `lpac` 架构或版本。
+- 安装脚本按设备架构自动准备带 QMI APDU 后端的私有 `lpac`，并校验 `qmi` / `curl` 驱动能力；OTA 包本身不绑定 `lpac` 架构或版本。
 - OTA 上传、在线下载、校验、替换二进制和前端资源。
 
 ---

--- a/backend/.cargo/config.toml
+++ b/backend/.cargo/config.toml
@@ -2,7 +2,10 @@
 linker = "aarch64-unknown-linux-musl-gcc"
 rustflags = ["-C", "target-feature=+crt-static"]
 
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-unknown-linux-musl-gcc"
+rustflags = ["-C", "target-feature=+crt-static"]
+
 # 为构建脚本配置本地编译器
 [target.aarch64-apple-darwin]
 linker = "cc"
-

--- a/backend/build.rs
+++ b/backend/build.rs
@@ -21,10 +21,16 @@ fn main() {
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
         .unwrap_or_else(|_| "unknown".to_string());
 
+    // Cargo exposes the selected compilation target to build scripts. Forward it
+    // to the application so OTA packages can be checked against the architecture
+    // of the running binary instead of a hard-coded target.
+    let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
+
     // Set compile-time environment variables
     println!("cargo:rustc-env=APP_VERSION={}", version);
     println!("cargo:rustc-env=GIT_BRANCH={}", branch);
     println!("cargo:rustc-env=GIT_COMMIT={}", commit);
+    println!("cargo:rustc-env=APP_TARGET_TRIPLE={}", target);
 
     // Rebuild if VERSION file changes
     println!("cargo:rerun-if-changed=../VERSION");

--- a/backend/src/esim.rs
+++ b/backend/src/esim.rs
@@ -420,10 +420,18 @@ fn find_version_token(text: &str) -> Option<String> {
 }
 
 fn recommended_lpac_asset_name(arch: &str, glibc_version: &str) -> String {
-    if arch == "aarch64" && version_le("2.31", glibc_version).unwrap_or(false) {
-        return "lpac-linux-aarch64-glibc2.31.zip".to_string();
+    if matches!(arch, "aarch64" | "x86_64") && version_le("2.31", glibc_version).unwrap_or(false) {
+        return format!("lpac-linux-{arch}-glibc2.31.zip");
     }
-    format!("lpac-linux-{arch}.zip")
+    format!("lpac-linux-{arch}-with-qmi.zip")
+}
+
+fn official_lpac_asset_names(arch: &str) -> [String; 3] {
+    [
+        format!("lpac-linux-{arch}-with-qmi.zip"),
+        format!("lpac-linux-{arch}.zip"),
+        format!("lpac-linux-{arch}-without-lto.zip"),
+    ]
 }
 
 async fn resolve_lpac_asset_candidates(
@@ -439,11 +447,7 @@ async fn resolve_lpac_asset_candidates(
         candidates.append(&mut manifest_candidates);
     }
 
-    for name in [
-        format!("lpac-linux-{arch}.zip"),
-        format!("lpac-linux-{arch}-with-qmi.zip"),
-        format!("lpac-linux-{arch}-without-lto.zip"),
-    ] {
+    for name in official_lpac_asset_names(arch) {
         candidates.push(LpacAssetCandidate {
             url: format!("{LPAC_OFFICIAL_RELEASE_BASE_URL}/{name}"),
             name,
@@ -532,7 +536,10 @@ fn parse_version_parts(value: &str) -> Vec<u32> {
 
 async fn probe_lpac_binary(command_path: &Path) -> LpacProbe {
     let mut command = tokio::process::Command::new(command_path);
+    command.args(["driver", "list"]);
     configure_lpac_environment(&mut command, command_path);
+    command.env("LPAC_APDU", "stdio");
+    command.env("LPAC_HTTP", "stdio");
 
     let output = match tokio::time::timeout(
         Duration::from_secs(LPAC_PROBE_TIMEOUT_SECS),
@@ -567,14 +574,28 @@ async fn probe_lpac_binary(command_path: &Path) -> LpacProbe {
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     let combined = format!("{stdout}\n{stderr}");
-    if combined.contains("GLIBC_")
-        || combined.contains("No such file or directory")
-        || combined.contains("Permission denied")
-    {
+    if !output.status.success() {
         return LpacProbe {
             installed: true,
             usable: false,
-            message: if stderr.is_empty() { stdout } else { stderr },
+            message: if stderr.is_empty() {
+                if stdout.is_empty() {
+                    format!("lpac driver probe exited with {}", output.status)
+                } else {
+                    stdout
+                }
+            } else {
+                stderr
+            },
+        };
+    }
+
+    if !lpac_driver_list_has_required_drivers(&combined) {
+        return LpacProbe {
+            installed: true,
+            usable: false,
+            message: "lpac does not provide the required qmi APDU and curl HTTP drivers"
+                .to_string(),
         };
     }
 
@@ -583,6 +604,25 @@ async fn probe_lpac_binary(command_path: &Path) -> LpacProbe {
         usable: true,
         message: "lpac is available".to_string(),
     }
+}
+
+fn lpac_driver_list_has_required_drivers(output: &str) -> bool {
+    let value = output
+        .lines()
+        .rev()
+        .find_map(|line| serde_json::from_str::<Value>(line.trim()).ok());
+    let Some(value) = value else {
+        return false;
+    };
+    let payload = value.get("payload").unwrap_or(&value);
+    let has_driver = |kind: &str, name: &str| {
+        payload
+            .get(kind)
+            .and_then(Value::as_array)
+            .map(|drivers| drivers.iter().any(|driver| driver.as_str() == Some(name)))
+            .unwrap_or(false)
+    };
+    has_driver("LPAC_APDU", "qmi") && has_driver("LPAC_HTTP", "curl")
 }
 
 fn read_lpac_source() -> Option<String> {
@@ -982,7 +1022,8 @@ fn resolve_lpac_path(lpac_path: &str) -> PathBuf {
 fn configure_lpac_environment(command: &mut tokio::process::Command, command_path: &Path) {
     set_env_default(command, "LPAC_APDU", "qmi");
     set_env_default(command, "LPAC_HTTP", "curl");
-    set_env_default(command, "LPAC_APDU_QMI_DEVICE", "/dev/wwan0qmi0");
+    let qmi_device = discover_lpac_qmi_device();
+    set_env_default(command, "LPAC_APDU_QMI_DEVICE", &qmi_device);
     set_env_default(command, "LPAC_APDU_QMI_UIM_SLOT", "1");
     set_env_default(command, "LPAC_APDU_AT_DEVICE", "/dev/wwan0at0");
 
@@ -1000,6 +1041,42 @@ fn configure_lpac_environment(command: &mut tokio::process::Command, command_pat
             command.env("LD_LIBRARY_PATH", ld_library_path);
         }
     }
+}
+
+fn discover_lpac_qmi_device() -> String {
+    let candidates = fs::read_dir("/dev")
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("");
+            name.starts_with("cdc-wdm") || (name.starts_with("wwan") && name.contains("qmi"))
+        })
+        .collect::<Vec<_>>();
+
+    select_lpac_qmi_device(candidates)
+        .unwrap_or_else(|| PathBuf::from("/dev/cdc-wdm0"))
+        .to_string_lossy()
+        .to_string()
+}
+
+fn select_lpac_qmi_device(mut candidates: Vec<PathBuf>) -> Option<PathBuf> {
+    candidates.sort_by(|left, right| {
+        let priority = |path: &Path| {
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("");
+            (!name.starts_with("cdc-wdm"), name.to_string())
+        };
+        priority(left).cmp(&priority(right))
+    });
+    candidates.into_iter().next()
 }
 
 fn set_env_default(command: &mut tokio::process::Command, key: &str, value: &str) {
@@ -1513,6 +1590,56 @@ fn policy_allows(value: &Value, deny_markers: &[&str]) -> Option<bool> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn recommends_compatible_lpac_for_supported_architectures() {
+        assert_eq!(
+            recommended_lpac_asset_name("x86_64", "2.39"),
+            "lpac-linux-x86_64-glibc2.31.zip"
+        );
+        assert_eq!(
+            recommended_lpac_asset_name("aarch64", "2.39"),
+            "lpac-linux-aarch64-glibc2.31.zip"
+        );
+        assert_eq!(
+            official_lpac_asset_names("x86_64")[0],
+            "lpac-linux-x86_64-with-qmi.zip"
+        );
+    }
+
+    #[test]
+    fn validates_required_lpac_drivers() {
+        let valid = json!({
+            "type": "driver",
+            "payload": {
+                "LPAC_APDU": ["qmi", "pcsc", "stdio"],
+                "LPAC_HTTP": ["curl", "stdio"]
+            }
+        });
+        let missing_qmi = json!({
+            "type": "driver",
+            "payload": {
+                "LPAC_APDU": ["pcsc", "at", "stdio"],
+                "LPAC_HTTP": ["curl", "stdio"]
+            }
+        });
+
+        assert!(lpac_driver_list_has_required_drivers(&valid.to_string()));
+        assert!(!lpac_driver_list_has_required_drivers(
+            &missing_qmi.to_string()
+        ));
+    }
+
+    #[test]
+    fn qmi_device_selection_prefers_cdc_wdm() {
+        let selected = select_lpac_qmi_device(vec![
+            PathBuf::from("/dev/wwan0qmi0"),
+            PathBuf::from("/dev/cdc-wdm1"),
+            PathBuf::from("/dev/cdc-wdm0"),
+        ]);
+
+        assert_eq!(selected, Some(PathBuf::from("/dev/cdc-wdm0")));
+    }
 
     #[test]
     fn parses_lpac_chip_info_aliases() {

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -4074,8 +4074,21 @@ pub async fn get_latest_ota_release_handler(
         let proxy_prefix = crate::ota::normalize_proxy_prefix(req.proxy_prefix);
         let client = crate::ota::build_ota_http_client()?;
 
-        crate::ota::fetch_latest_github_release(&client, &proxy_prefix, include_builtin_proxies)
-            .await
+        let mut release = crate::ota::fetch_latest_github_release(
+            &client,
+            &proxy_prefix,
+            include_builtin_proxies,
+        )
+        .await?;
+
+        // The UI historically displays the first archive. Return only the asset
+        // that matches this running binary so multi-architecture releases cannot
+        // offer an arm64 package to x86_64 devices (or vice versa).
+        release.assets = crate::ota::supported_release_asset(&release)
+            .cloned()
+            .into_iter()
+            .collect();
+        Ok(release)
     }
     .await;
 

--- a/backend/src/ota.rs
+++ b/backend/src/ota.rs
@@ -26,6 +26,7 @@ const NM_CONF_DIR: &str = "/etc/NetworkManager/conf.d";
 const NM_CONF_PATH: &str = "/etc/NetworkManager/conf.d/99-simadmin-unmanaged-modem.conf";
 const NM_UNMANAGED_WWAN_CONFIG: &str = "[keyfile]\nunmanaged-devices=interface-name:wwan*\n";
 const LATEST_RELEASE_API: &str = "https://api.github.com/repos/3899/SimAdmin/releases/latest";
+const CURRENT_TARGET_TRIPLE: &str = env!("APP_TARGET_TRIPLE");
 const BEIJING_UTC_OFFSET_SECONDS: i32 = 8 * 60 * 60;
 const UPDATE_CHECK_HOURS: [u32; 2] = [9, 18];
 const OTA_HTTP_TIMEOUT_SECS: u64 = 30;
@@ -143,14 +144,64 @@ pub fn ota_request_urls(
 
 pub fn is_supported_ota_asset(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
-    lower.ends_with(".tar.gz") || lower.ends_with(".tgz") || lower.ends_with(".zip")
+    lower.starts_with("simadmin")
+        && (lower.ends_with(".tar.gz") || lower.ends_with(".tgz") || lower.ends_with(".zip"))
 }
 
-pub fn supported_release_asset(release: &OtaLatestReleaseResponse) -> Option<&OtaReleaseAsset> {
+fn ota_asset_score(name: &str, target: &str) -> Option<u8> {
+    if !is_supported_ota_asset(name) {
+        return None;
+    }
+
+    let lower = name.to_ascii_lowercase();
+    let target = target.to_ascii_lowercase();
+    if lower.contains(&target) {
+        return Some(3);
+    }
+
+    // A fully-qualified package for another libc/ABI is not an architecture
+    // alias and must not be selected as a fallback.
+    if lower.contains("unknown-linux-") {
+        return None;
+    }
+
+    let arch_match = match target.as_str() {
+        "aarch64-unknown-linux-musl" => lower.contains("aarch64") || lower.contains("arm64"),
+        "x86_64-unknown-linux-musl" => lower.contains("x86_64") || lower.contains("amd64"),
+        _ => false,
+    };
+    if arch_match {
+        return Some(2);
+    }
+
+    // `simadmin.tar.gz` was the historical aarch64-only release name. Keep it
+    // as an arm64 fallback, but never install it on x86_64.
+    if target == "aarch64-unknown-linux-musl"
+        && matches!(
+            lower.as_str(),
+            "simadmin.tar.gz" | "simadmin.tgz" | "simadmin.zip"
+        )
+    {
+        return Some(1);
+    }
+
+    None
+}
+
+fn supported_release_asset_for_target<'a>(
+    release: &'a OtaLatestReleaseResponse,
+    target: &str,
+) -> Option<&'a OtaReleaseAsset> {
     release
         .assets
         .iter()
-        .find(|asset| is_supported_ota_asset(&asset.name))
+        .filter_map(|asset| ota_asset_score(&asset.name, target).map(|score| (score, asset)))
+        .max_by_key(|(score, _)| *score)
+        .map(|(_, asset)| asset)
+}
+
+pub fn supported_release_asset(release: &OtaLatestReleaseResponse) -> Option<&OtaReleaseAsset> {
+    supported_release_asset_for_target(release, CURRENT_TARGET_TRIPLE)
 }
 
 pub async fn fetch_latest_github_release(
@@ -437,8 +488,8 @@ fn validate_ota_package(meta: &OtaMeta) -> Result<OtaValidation, String> {
     // 前端目录存在即可（MD5 跨平台难以保持一致）
     let frontend_md5_match = true; // 跳过前端 MD5 验证
 
-    // 检查架构（只接受 musl）
-    let arch_match = meta.arch == "aarch64-unknown-linux-musl";
+    // OTA 二进制必须与当前运行实例的编译目标完全一致。
+    let arch_match = meta.arch == CURRENT_TARGET_TRIPLE;
 
     // 比较版本
     let is_newer = compare_versions(&meta.version, CURRENT_VERSION);
@@ -457,8 +508,8 @@ fn validate_ota_package(meta: &OtaMeta) -> Result<OtaValidation, String> {
         }
         if !arch_match {
             errors.push(format!(
-                "Arch mismatch: expected=aarch64-unknown-linux-musl, actual={}",
-                meta.arch
+                "Arch mismatch: expected={}, actual={}",
+                CURRENT_TARGET_TRIPLE, meta.arch
             ));
         }
         Some(errors.join("; "))
@@ -744,6 +795,71 @@ mod tests {
         assert!(compare_versions("v1.0.4", "1.0.3"));
         assert!(!compare_versions("v1.0.3", "1.0.3"));
         assert!(!compare_versions("v1.0.2", "1.0.3"));
+    }
+
+    #[test]
+    fn selects_the_release_asset_for_the_requested_architecture() {
+        let release = OtaLatestReleaseResponse {
+            assets: vec![
+                OtaReleaseAsset {
+                    name: "simadmin.tar.gz".to_string(),
+                    ..Default::default()
+                },
+                OtaReleaseAsset {
+                    name: "simadmin-aarch64-unknown-linux-musl.tar.gz".to_string(),
+                    ..Default::default()
+                },
+                OtaReleaseAsset {
+                    name: "simadmin-x86_64-unknown-linux-musl.tar.gz".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            supported_release_asset_for_target(&release, "aarch64-unknown-linux-musl")
+                .map(|asset| asset.name.as_str()),
+            Some("simadmin-aarch64-unknown-linux-musl.tar.gz")
+        );
+        assert_eq!(
+            supported_release_asset_for_target(&release, "x86_64-unknown-linux-musl")
+                .map(|asset| asset.name.as_str()),
+            Some("simadmin-x86_64-unknown-linux-musl.tar.gz")
+        );
+    }
+
+    #[test]
+    fn generic_legacy_asset_is_arm64_only() {
+        let release = OtaLatestReleaseResponse {
+            assets: vec![OtaReleaseAsset {
+                name: "simadmin.tar.gz".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        assert!(
+            supported_release_asset_for_target(&release, "aarch64-unknown-linux-musl").is_some()
+        );
+        assert!(
+            supported_release_asset_for_target(&release, "x86_64-unknown-linux-musl").is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_a_fully_qualified_asset_for_another_abi() {
+        let release = OtaLatestReleaseResponse {
+            assets: vec![OtaReleaseAsset {
+                name: "simadmin-x86_64-unknown-linux-gnu.tar.gz".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        assert!(
+            supported_release_asset_for_target(&release, "x86_64-unknown-linux-musl").is_none()
+        );
     }
 
     #[test]

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -69,9 +69,10 @@ cargo run -- --host :: --port 3000
 ./scripts/build.sh --frontend-only
 ./scripts/build.sh --no-upx
 ./scripts/build.sh --no-ota
+./scripts/build.sh --target=x86_64
 ```
 
-*Windows 下建议在 WSL2 Ubuntu 中执行完整 OTA 构建。原生 PowerShell 不能直接运行 Bash 脚本；Git Bash 容易受 Node/npm/pnpm PATH 影响，完整 OTA 仍需要 `aarch64-unknown-linux-musl-gcc` 等 Linux 交叉编译工具链：*
+*Windows 下建议在 WSL2 Ubuntu 中执行完整 OTA 构建。原生 PowerShell 不能直接运行 Bash 脚本；Git Bash 容易受 Node/npm/pnpm PATH 影响，完整 OTA 仍需要目标架构对应的 Linux musl 工具链：*
 
 ```bash
 ./scripts/build.sh --no-upx
@@ -81,9 +82,11 @@ cargo run -- --host :: --port 3000
 
 - 同步 `VERSION` 到 `backend/Cargo.toml` 和 `frontend/package.json`。
 - 使用 `pnpm-lock.yaml` 时通过 `pnpm install --frozen-lockfile`、`pnpm run lint` 和 `pnpm exec vite build` 构建前端到 `frontend/dist/`。
-- 交叉编译后端到 `backend/target/aarch64-unknown-linux-musl/release/simadmin`。
+- 默认交叉编译后端到 `backend/target/aarch64-unknown-linux-musl/release/simadmin`；传入 `--target=x86_64` 时生成 `backend/target/x86_64-unknown-linux-musl/release/simadmin`。
 - 可选使用 UPX 压缩后端二进制；未安装 UPX 时会自动跳过压缩。
-- 生成 `release/simadmin_<version>.tar.gz` OTA 包。
+- 生成 `release/simadmin_<version>_<target>.tar.gz` OTA 包，并在 `meta.json` 中写入相同 target triple。
+
+GitHub Actions 会在 ARM64 与 x86_64 原生 runner 上并行构建，发布两个带架构名称的 OTA 包；`simadmin.tar.gz` 继续作为 ARM64 兼容别名。
 
 ### 通过 ADB 部署
 
@@ -98,6 +101,7 @@ cargo run -- --host :: --port 3000
 ./scripts/deploy.sh --frontend-only
 ./scripts/deploy.sh --no-restart
 ./scripts/deploy.sh --target=/opt/simadmin
+./scripts/deploy.sh --build-target=x86_64
 ```
 
 ---

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -3,6 +3,7 @@
 ## 目标设备运行要求
 
 - **操作系统**：Linux / Debian 系统。
+- **CPU 架构**：ARM64 (`aarch64`) 或 x86_64 (`amd64`)；安装与 OTA 包必须和设备架构一致。
 - **系统管理器**：systemd。
 - **权限**：需要 root 运行权限。
 - **IPC 机制**：system D-Bus。
@@ -10,6 +11,7 @@
   - `ModemManager` 和 `mmcli`
   - `NetworkManager` 和 `nmcli`
   - `qmicli`（用于基站定位/网络小区信息兜底读取）
+  - `libqmi` / `libmbim` / `libpcsclite`（`lpac` QMI APDU 后端的动态链接依赖）
   - `iptables` / `ip6tables`（仅用于网络通路只读诊断；本程序不会自动修改或清空防火墙规则）
   - `ip` / `ifconfig` / `route`（用于网络状态诊断，其中 `ifconfig` 和 `route` 需确保系统已安装 `net-tools`）
   - `tar`（OTA 包解压必需）
@@ -33,7 +35,7 @@
 | `/etc/systemd/system/simadmin.service` | SimAdmin 后端主服务守护单元 |
 | `/etc/systemd/system/simadmin-modem-recovery.service` | 开机 modem 搜网异常自愈恢复服务单元 |
 | `/usr/local/bin/simadmin-modem-recovery.sh` | 开机自愈监控与搜网状态恢复的执行脚本 |
-| `/etc/NetworkManager/conf.d/99-simadmin-unmanaged-modem.conf` | NetworkManager 忽略托管 `wwan*` 接口配置，避免与主服务抢占调制解调器控制权 |
+| `/etc/NetworkManager/conf.d/99-simadmin-unmanaged-modem.conf` | 仅为旧版本遗留配置；新安装会删除它，使 NetworkManager 可以管理蜂窝连接 |
 
 ---
 
@@ -44,7 +46,8 @@
 * **普通 SIM 模式**：「SIM 卡管理」页面中将隐藏「eSIM 管理」标签页，`/api/esim/*` 所有相关接口返回 `403`，前端不加载 eSIM 关联页面 chunk 资源，后端不会主动拉起或调用 `lpac`。
 * **eSIM 模式**：切换到 eSIM 模式后，只有切入「eSIM 管理」Tab 页或用户执行 Profile 写卡、切换、重命名等操作时，后端才会按需调用 `lpac chip info`、`lpac profile list`、`lpac profile enable`、`lpac profile nickname` 和 `lpac profile delete` 进行瞬时通信。
 * **`lpac` 下载与维护**：
-  - 一键安装脚本 `install_latest.sh` 会根据 `uname -m` 和 glibc 版本，优先匹配架构并拉取 ESTK 的 `lpac` 静态编译程序至 `/opt/simadmin/lpac/lpac`。如果系统已存在可用版本则跳过下载。如果需要阻止脚本下载，请在安装时设置环境变量 `SIMADMIN_INSTALL_LPAC=0`。
+  - 一键安装脚本 `install_latest.sh` 会根据 `uname -m` 和 glibc 版本，优先匹配架构并拉取带 QMI APDU 后端的 `lpac` 至 `/opt/simadmin/lpac/lpac`。脚本通过 `lpac driver list` 校验 `qmi` 和 `curl` 驱动，缺少所需驱动或动态库时不会覆盖已有可用版本。如果需要阻止脚本下载，请在安装时设置环境变量 `SIMADMIN_INSTALL_LPAC=0`。
+  - 后端默认自动选择 `/dev/cdc-wdm*` QMI 设备，并兼容 `/dev/wwan*qmi*`；仍可通过 `LPAC_APDU_QMI_DEVICE` 显式覆盖。
   - 单独手动应用 OTA 包**不会**自动安装或升级 `lpac`。
   - 若系统检测到有 eSIM 支持却缺失 `lpac`，管理页面会提供「安装/修复 lpac」的便捷入口。其内部修复逻辑由后端内置 zip 解压引擎在内存中运行完成，不依赖外部环境命令。
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,12 +24,21 @@ curl -fsSL https://raw.githubusercontent.com/3899/SimAdmin/main/install_latest.s
 
 ### 安装脚本动作说明
 
-- 从 GitHub Release 下载 `simadmin.tar.gz`。
+- 根据 `uname -m` 自动选择 GitHub Release 中的 ARM64 或 x86_64 musl 包。
+- ARM64 新包不可用时会回退到历史兼容文件名 `simadmin.tar.gz`；x86_64 不会使用该 ARM64 旧包。
+- 解压后校验 `meta.json` 中的架构，再替换当前程序。
+- 在 Debian / Ubuntu 上自动安装 ModemManager、NetworkManager、QMI/MBIM、PC/SC、udev 和解压工具等运行依赖。
+- 启用 ModemManager 与 NetworkManager，重新加载 udev 规则并触发已有 modem 设备重新识别。
 - 安装后端二进制到 `/opt/simadmin/simadmin`。
 - 安装前端到 `/opt/simadmin/www`。
+- 下载带 QMI APDU 后端的架构匹配 `lpac`，在替换旧版本前校验 `qmi` / `curl` 驱动和动态库完整性。
 - 安装并启用 `simadmin.service`。
 - 安装并启用 `simadmin-modem-recovery.service`。
-- 配置 NetworkManager 忽略 `wwan*` 接口，避免与 SimAdmin 抢占蜂窝连接管理。
+- 删除旧版本遗留的 NetworkManager `wwan*` unmanaged 配置，使 `nmcli` 能管理蜂窝连接。
+
+当前官方构建目标为 `aarch64-unknown-linux-musl` 和 `x86_64-unknown-linux-musl`。如需覆盖自动检测，可设置 `SIMADMIN_TARGET_ARCH=arm64` 或 `SIMADMIN_TARGET_ARCH=amd64`；也可以通过 `ASSET_NAME` / `ASSET_URL` 指定自定义产物。
+
+如需保留宿主机现有网络管理方式，可设置 `SIMADMIN_ENABLE_NETWORKMANAGER=0`，脚本仍会安装 `nmcli`，但不会启用 NetworkManager；此时 SimAdmin 的 WLAN 和蜂窝数据连接功能不可用。还可以用 `SIMADMIN_INSTALL_SYSTEM_DEPS=0` 跳过 apt 依赖安装，或用 `SIMADMIN_REFRESH_MODEM_DEVICES=0` 跳过 udev 设备刷新。
 
 ---
 

--- a/frontend/src/pages/OtaUpdate.tsx
+++ b/frontend/src/pages/OtaUpdate.tsx
@@ -122,7 +122,7 @@ function getReleaseAsset(release: OtaLatestReleaseResponse) {
 function inferArch(assetName?: string) {
   if (!assetName) return '未知'
   if (/aarch64|arm64/i.test(assetName)) return 'aarch64-unknown-linux-musl'
-  if (/x86_64|amd64/i.test(assetName)) return 'x86_64-unknown-linux-gnu'
+  if (/x86_64|amd64/i.test(assetName)) return 'x86_64-unknown-linux-musl'
   if (/armv7|armhf/i.test(assetName)) return 'armv7-unknown-linux-musleabihf'
   return '未知'
 }

--- a/install_latest.sh
+++ b/install_latest.sh
@@ -13,12 +13,16 @@ SERVICE_URL="${SERVICE_URL:-${RAW_BASE}/main/scripts/simadmin.service}"
 MODEM_RECOVERY_SCRIPT_URL="${MODEM_RECOVERY_SCRIPT_URL:-${RAW_BASE}/main/scripts/simadmin-modem-recovery.sh}"
 MODEM_RECOVERY_SERVICE_URL="${MODEM_RECOVERY_SERVICE_URL:-${RAW_BASE}/main/scripts/simadmin-modem-recovery.service}"
 ASSET_URL="${ASSET_URL:-}"
-ASSET_NAME="${ASSET_NAME:-simadmin.tar.gz}"
+ASSET_NAME="${ASSET_NAME:-}"
+SIMADMIN_TARGET_ARCH="${SIMADMIN_TARGET_ARCH:-}"
+SIMADMIN_INSTALL_SYSTEM_DEPS="${SIMADMIN_INSTALL_SYSTEM_DEPS:-1}"
+SIMADMIN_ENABLE_NETWORKMANAGER="${SIMADMIN_ENABLE_NETWORKMANAGER:-1}"
+SIMADMIN_REFRESH_MODEM_DEVICES="${SIMADMIN_REFRESH_MODEM_DEVICES:-1}"
 SIMADMIN_INSTALL_LPAC="${SIMADMIN_INSTALL_LPAC:-1}"
 LPAC_REPO="${LPAC_REPO:-estkme-group/lpac}"
 LPAC_RELEASE_BASE_URL="${LPAC_RELEASE_BASE_URL:-https://github.com/${LPAC_REPO}/releases/latest/download}"
 LPAC_LATEST_RELEASE_URL="${LPAC_LATEST_RELEASE_URL:-https://github.com/${LPAC_REPO}/releases/latest}"
-LPAC_COMPAT_RELEASE_BASE_URL="${LPAC_COMPAT_RELEASE_BASE_URL:-https://github.com/3899/SimAdmin/releases/download/lpac}"
+LPAC_COMPAT_RELEASE_BASE_URL="${LPAC_COMPAT_RELEASE_BASE_URL:-https://github.com/${REPO}/releases/download/lpac}"
 LPAC_COMPAT_MANIFEST_NAME="${LPAC_COMPAT_MANIFEST_NAME:-lpac.json}"
 LPAC_TARGET_ARCH="${LPAC_TARGET_ARCH:-}"
 LPAC_TARGET_VERSION="${LPAC_TARGET_VERSION:-}"
@@ -46,6 +50,75 @@ truthy() {
     1|true|TRUE|yes|YES|y|Y|on|ON) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+install_system_dependencies() {
+  if ! truthy "$SIMADMIN_INSTALL_SYSTEM_DEPS"; then
+    echo "==> skipping system dependency installation (SIMADMIN_INSTALL_SYSTEM_DEPS=${SIMADMIN_INSTALL_SYSTEM_DEPS})"
+    return 0
+  fi
+
+  if ! command -v apt-get >/dev/null 2>&1; then
+    echo "warning: apt-get is unavailable; install ModemManager, NetworkManager, libqmi, libmbim and libpcsclite manually" >&2
+    return 0
+  fi
+
+  echo "==> installing Debian/Ubuntu runtime dependencies"
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    dbus \
+    iproute2 \
+    libmbim-utils \
+    libpcsclite1 \
+    libqmi-utils \
+    modemmanager \
+    network-manager \
+    tar \
+    udev \
+    unzip
+}
+
+remove_legacy_networkmanager_modem_unmanaged() {
+  nm_conf="/etc/NetworkManager/conf.d/99-simadmin-unmanaged-modem.conf"
+  if [ -f "$nm_conf" ]; then
+    echo "==> removing legacy NetworkManager wwan unmanaged configuration"
+    rm -f "$nm_conf"
+  fi
+}
+
+start_runtime_services() {
+  echo "==> enabling ModemManager"
+  systemctl enable --now ModemManager.service >/dev/null
+
+  if truthy "$SIMADMIN_ENABLE_NETWORKMANAGER"; then
+    echo "==> enabling NetworkManager"
+    systemctl enable --now NetworkManager.service >/dev/null
+  else
+    echo "==> leaving NetworkManager inactive (SIMADMIN_ENABLE_NETWORKMANAGER=${SIMADMIN_ENABLE_NETWORKMANAGER})"
+    echo "    nmcli-dependent WLAN and cellular data features will remain unavailable"
+  fi
+}
+
+refresh_modem_devices() {
+  if ! truthy "$SIMADMIN_REFRESH_MODEM_DEVICES"; then
+    echo "==> skipping modem udev refresh (SIMADMIN_REFRESH_MODEM_DEVICES=${SIMADMIN_REFRESH_MODEM_DEVICES})"
+    return 0
+  fi
+
+  if command -v udevadm >/dev/null 2>&1; then
+    echo "==> reloading udev rules and refreshing modem candidates"
+    udevadm control --reload-rules
+    for subsystem in usb tty usbmisc net; do
+      udevadm trigger --action=change --subsystem-match="$subsystem" || true
+    done
+    udevadm settle --timeout=15 || true
+  else
+    echo "warning: udevadm is unavailable; reconnect the modem after installation" >&2
+  fi
+
+  systemctl restart ModemManager.service
 }
 
 download_with_proxies() {
@@ -106,7 +179,44 @@ version_to_tag() {
 
 asset_url_from_tag() {
   tag="$1"
-  printf 'https://github.com/%s/releases/download/%s/simadmin.tar.gz\n' "$REPO" "$tag"
+  simadmin_asset_name="$(resolve_simadmin_asset_name)"
+  printf 'https://github.com/%s/releases/download/%s/%s\n' "$REPO" "$tag" "$simadmin_asset_name"
+}
+
+normalize_simadmin_arch() {
+  case "$1" in
+    aarch64|arm64)
+      printf '%s\n' "aarch64"
+      ;;
+    x86_64|amd64)
+      printf '%s\n' "x86_64"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+detect_simadmin_arch() {
+  if [ -n "$SIMADMIN_TARGET_ARCH" ]; then
+    normalize_simadmin_arch "$SIMADMIN_TARGET_ARCH"
+    return $?
+  fi
+
+  normalize_simadmin_arch "$(uname -m)"
+}
+
+resolve_simadmin_asset_name() {
+  if [ -n "$ASSET_NAME" ]; then
+    printf '%s\n' "$ASSET_NAME"
+    return 0
+  fi
+
+  simadmin_arch="$(detect_simadmin_arch)" || {
+    echo "error: unsupported architecture: $(uname -m)" >&2
+    return 1
+  }
+  printf 'simadmin-%s-unknown-linux-musl.tar.gz\n' "$simadmin_arch"
 }
 
 repo_version() {
@@ -124,7 +234,7 @@ resolve_asset_url() {
   fi
 
   if [ "$VERSION" = "latest" ]; then
-    printf 'https://github.com/%s/releases/latest/download/%s\n' "$REPO" "$ASSET_NAME"
+    printf 'https://github.com/%s/releases/latest/download/%s\n' "$REPO" "$(resolve_simadmin_asset_name)"
   else
     asset_url_from_tag "$(version_to_tag "$VERSION")"
   fi
@@ -141,10 +251,26 @@ fallback_asset_url() {
   return 1
 }
 
+legacy_arm64_asset_url() {
+  if [ -n "$ASSET_URL" ] || [ -n "$ASSET_NAME" ]; then
+    return 1
+  fi
+  if [ "$(detect_simadmin_arch)" != "aarch64" ]; then
+    return 1
+  fi
+
+  if [ "$VERSION" = "latest" ]; then
+    printf 'https://github.com/%s/releases/latest/download/simadmin.tar.gz\n' "$REPO"
+  else
+    printf 'https://github.com/%s/releases/download/%s/simadmin.tar.gz\n' "$REPO" "$(version_to_tag "$VERSION")"
+  fi
+}
+
 download_release_asset() {
   archive_path="$1"
   primary_url="$2"
   fallback_url=""
+  legacy_url=""
 
   echo "==> downloading release asset"
   if download_with_proxies "$primary_url" "$archive_path"; then
@@ -158,10 +284,22 @@ download_release_asset() {
     fi
   fi
 
+  if legacy_url="$(legacy_arm64_asset_url)" \
+    && [ "$legacy_url" != "$primary_url" ] \
+    && [ "$legacy_url" != "$fallback_url" ]; then
+    echo "==> architecture-specific asset unavailable, trying legacy arm64 asset"
+    if download_with_proxies "$legacy_url" "$archive_path"; then
+      return 0
+    fi
+  fi
+
   echo "error: failed to download OTA asset" >&2
   echo "       tried: $primary_url" >&2
   if [ -n "$fallback_url" ]; then
     echo "       tried: $fallback_url" >&2
+  fi
+  if [ -n "$legacy_url" ]; then
+    echo "       tried: $legacy_url" >&2
   fi
   exit 1
 }
@@ -184,24 +322,6 @@ install_modem_recovery_service() {
   download_with_proxies "$MODEM_RECOVERY_SERVICE_URL" "$service_dst"
   systemctl daemon-reload
   systemctl enable simadmin-modem-recovery.service >/dev/null
-}
-
-configure_networkmanager_modem_unmanaged() {
-  if [ ! -d /etc/NetworkManager ]; then
-    return 0
-  fi
-
-  echo "==> configuring NetworkManager to ignore wwan modem"
-  mkdir -p /etc/NetworkManager/conf.d
-  nm_conf="/etc/NetworkManager/conf.d/99-simadmin-unmanaged-modem.conf"
-  {
-    printf '%s\n' '[keyfile]'
-    printf '%s\n' 'unmanaged-devices=interface-name:wwan*'
-  } > "$nm_conf"
-
-  if systemctl is-active --quiet NetworkManager.service; then
-    systemctl restart NetworkManager.service || true
-  fi
 }
 
 normalize_lpac_arch() {
@@ -297,11 +417,7 @@ resolve_lpac_asset_name() {
   case "$LPAC_ASSET_FLAVOR" in
     compat)
       glibc_version="$(detect_glibc_version)"
-      if [ "$arch" = "aarch64" ] && version_le "2.31" "$glibc_version"; then
-        printf 'lpac-linux-aarch64-glibc2.31.zip\n'
-      else
-        printf 'lpac-linux-%s.zip\n' "$arch"
-      fi
+      resolve_lpac_compat_asset_name "$arch" "$glibc_version"
       ;;
     ""|default)
       printf 'lpac-linux-%s.zip\n' "$arch"
@@ -319,6 +435,18 @@ resolve_lpac_asset_name() {
   esac
 }
 
+resolve_lpac_compat_asset_name() {
+  arch="$1"
+  glibc_version="$2"
+
+  if { [ "$arch" = "aarch64" ] || [ "$arch" = "x86_64" ]; } \
+    && version_le "2.31" "$glibc_version"; then
+    printf 'lpac-linux-%s-glibc2.31.zip\n' "$arch"
+  else
+    printf 'lpac-linux-%s-with-qmi.zip\n' "$arch"
+  fi
+}
+
 resolve_lpac_asset_url() {
   if [ -n "$LPAC_ASSET_URL" ]; then
     printf '%s\n' "$LPAC_ASSET_URL"
@@ -327,9 +455,13 @@ resolve_lpac_asset_url() {
 
   arch="$(detect_lpac_arch)" || return 1
   asset_name="$(resolve_lpac_asset_name "$arch")" || return 1
-  if [ "$LPAC_ASSET_FLAVOR" = "compat" ] && [ "$asset_name" = "lpac-linux-aarch64-glibc2.31.zip" ]; then
-    printf '%s/%s\n' "$LPAC_COMPAT_RELEASE_BASE_URL" "$asset_name"
-    return 0
+  if [ "$LPAC_ASSET_FLAVOR" = "compat" ]; then
+    case "$asset_name" in
+      lpac-linux-aarch64-glibc2.31.zip|lpac-linux-x86_64-glibc2.31.zip)
+        printf '%s/%s\n' "$LPAC_COMPAT_RELEASE_BASE_URL" "$asset_name"
+        return 0
+        ;;
+    esac
   fi
   printf '%s/%s\n' "$LPAC_RELEASE_BASE_URL" "$asset_name"
 }
@@ -372,43 +504,43 @@ PY
 }
 
 copy_lpac_tree() {
-  extract_dir="$1"
-  lpac_dst="$2"
-  asset_url="$3"
+  copy_extract_dir="$1"
+  copy_destination="$2"
+  copy_asset_url="$3"
 
-  if [ -f "${extract_dir}/lpac" ]; then
-    bundle_root="${extract_dir}"
-  elif [ -f "${extract_dir}/executables/lpac" ]; then
-    bundle_root="${extract_dir}/executables"
+  if [ -f "${copy_extract_dir}/lpac" ]; then
+    copy_bundle_root="${copy_extract_dir}"
+  elif [ -f "${copy_extract_dir}/executables/lpac" ]; then
+    copy_bundle_root="${copy_extract_dir}/executables"
   else
-    bundle_root="$(find "$extract_dir" -type f -name lpac -exec dirname {} \; | head -n 1 || true)"
+    copy_bundle_root="$(find "$copy_extract_dir" -type f -name lpac -exec dirname {} \; | head -n 1 || true)"
   fi
 
-  if [ -z "$bundle_root" ] || [ ! -f "${bundle_root}/lpac" ]; then
+  if [ -z "$copy_bundle_root" ] || [ ! -f "${copy_bundle_root}/lpac" ]; then
     echo "warning: downloaded lpac asset does not contain lpac executable" >&2
     return 1
   fi
 
-  rm -rf "${lpac_dst}"
-  mkdir -p "${lpac_dst}"
-  cp -R "${bundle_root}/." "${lpac_dst}/"
+  rm -rf "${copy_destination}"
+  mkdir -p "${copy_destination}"
+  cp -R "${copy_bundle_root}/." "${copy_destination}/"
 
-  if [ -d "${extract_dir}/lib" ] && [ ! -d "${lpac_dst}/lib" ]; then
-    mkdir -p "${lpac_dst}/lib"
-    cp -R "${extract_dir}/lib/." "${lpac_dst}/lib/"
+  if [ -d "${copy_extract_dir}/lib" ] && [ ! -d "${copy_destination}/lib" ]; then
+    mkdir -p "${copy_destination}/lib"
+    cp -R "${copy_extract_dir}/lib/." "${copy_destination}/lib/"
   fi
 
-  if [ -d "${extract_dir}/libraries" ] && [ ! -d "${lpac_dst}/lib" ]; then
-    mkdir -p "${lpac_dst}/lib"
-    cp -R "${extract_dir}/libraries/." "${lpac_dst}/lib/"
+  if [ -d "${copy_extract_dir}/libraries" ] && [ ! -d "${copy_destination}/lib" ]; then
+    mkdir -p "${copy_destination}/lib"
+    cp -R "${copy_extract_dir}/libraries/." "${copy_destination}/lib/"
   fi
 
-  chmod -R a+rX "${lpac_dst}"
-  chmod 0755 "${lpac_dst}/lpac"
+  chmod -R a+rX "${copy_destination}"
+  chmod 0755 "${copy_destination}/lpac"
 
-  cat > "${lpac_dst}/SOURCE.txt" <<EOF
+  cat > "${copy_destination}/SOURCE.txt" <<EOF
 lpac is installed from:
-${asset_url}
+${copy_asset_url}
 
 Project:
 https://github.com/estkme-group/lpac
@@ -427,12 +559,24 @@ lpac_binary_path_usable() {
     return 1
   fi
 
-  output=$(LD_LIBRARY_PATH="$(lpac_env_prefix "$lpac_path")" "$lpac_path" 2>&1 || true)
+  if ! output=$(LPAC_APDU=stdio LPAC_HTTP=stdio \
+    LD_LIBRARY_PATH="$(lpac_env_prefix "$lpac_path")" \
+    "$lpac_path" driver list 2>&1); then
+    return 1
+  fi
   case "$output" in
-    *GLIBC_*|*No\ such\ file\ or\ directory*)
+    *GLIBC_*|*No\ such\ file\ or\ directory*|*Permission\ denied*|*error\ while\ loading\ shared\ libraries*)
       return 1
       ;;
   esac
+
+  compact_output="$(printf '%s' "$output" | tr -d '[:space:]')"
+  if ! printf '%s\n' "$compact_output" | grep -Eq '"LPAC_APDU":\[[^]]*"qmi"'; then
+    return 1
+  fi
+  if ! printf '%s\n' "$compact_output" | grep -Eq '"LPAC_HTTP":\[[^]]*"curl"'; then
+    return 1
+  fi
 
   return 0
 }
@@ -510,7 +654,7 @@ lpac_asset_name_from_url() {
 lpac_url_source() {
   url="$1"
   case "$url" in
-    "$LPAC_COMPAT_RELEASE_BASE_URL"/*|https://github.com/3899/SimAdmin/releases/download/lpac/*)
+    "$LPAC_COMPAT_RELEASE_BASE_URL"/*|https://github.com/"$REPO"/releases/download/lpac/*)
       printf '%s\n' "compat"
       ;;
     "$LPAC_RELEASE_BASE_URL"/*|https://github.com/"$LPAC_REPO"/releases/latest/download/*|https://github.com/"$LPAC_REPO"/releases/download/*)
@@ -637,12 +781,57 @@ write_lpac_version_file() {
   chmod 0644 "${lpac_home}/VERSION.txt" || true
 }
 
+lpac_installed_compat_revision() {
+  lpac_path="$1"
+  revision_file="$(dirname "$lpac_path")/COMPAT_REVISION.txt"
+  [ -f "$revision_file" ] || return 1
+
+  revision="$(tr -d '[:space:]' < "$revision_file")"
+  case "$revision" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf '%s\n' "$revision"
+}
+
+compat_lpac_release_revision() {
+  lpac_url="$1"
+  manifest_url="${LPAC_COMPAT_RELEASE_BASE_URL}/${LPAC_COMPAT_MANIFEST_NAME}"
+  manifest="$(read_with_proxies "$manifest_url" 2>/dev/null || true)"
+  [ -n "$manifest" ] || return 1
+
+  asset_name="$(lpac_asset_name_from_url "$lpac_url")"
+  [ -n "$asset_name" ] || return 1
+  asset_record="$(printf '%s\n' "$manifest" \
+    | tr '\n' ' ' \
+    | sed 's/}[[:space:]]*,[[:space:]]*{/}\
+{/g' \
+    | grep "\"name\"[[:space:]]*:[[:space:]]*\"${asset_name}\"" \
+    | head -n 1 || true)"
+  revision="$(printf '%s\n' "$asset_record" | json_string_field compat_revision)"
+  [ -n "$revision" ] || revision="$(printf '%s\n' "$manifest" | json_string_field compat_revision)"
+  case "$revision" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf '%s\n' "$revision"
+}
+
+write_lpac_compat_revision_file() {
+  lpac_home="$1"
+  revision="$2"
+  case "$revision" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  printf '%s\n' "$revision" > "${lpac_home}/COMPAT_REVISION.txt"
+  chmod 0644 "${lpac_home}/COMPAT_REVISION.txt" || true
+}
+
 lpac_install_needed() {
   lpac_path="$1"
   lpac_url="$2"
   LPAC_INSTALL_REASON=""
   LPAC_TARGET_RELEASE_VERSION=""
   LPAC_TARGET_RELEASE_SOURCE=""
+  LPAC_TARGET_COMPAT_REVISION=""
 
   if [ -z "$lpac_path" ] || [ ! -x "$lpac_path" ]; then
     LPAC_INSTALL_REASON="not installed"
@@ -660,10 +849,23 @@ lpac_install_needed() {
     return 0
   fi
 
+  LPAC_TARGET_RELEASE_SOURCE="$(lpac_url_source "$lpac_url")"
   LPAC_TARGET_RELEASE_VERSION="$(resolve_lpac_target_version "$lpac_url" || true)"
   if [ -z "$LPAC_TARGET_RELEASE_VERSION" ]; then
     LPAC_INSTALL_REASON="latest version could not be verified"
     return 0
+  fi
+
+  if [ "$LPAC_TARGET_RELEASE_SOURCE" = "compat" ]; then
+    LPAC_TARGET_COMPAT_REVISION="$(compat_lpac_release_revision "$lpac_url" || true)"
+    if [ -n "$LPAC_TARGET_COMPAT_REVISION" ]; then
+      installed_compat_revision="$(lpac_installed_compat_revision "$lpac_path" || true)"
+      if [ -z "$installed_compat_revision" ] \
+        || version_lt "$installed_compat_revision" "$LPAC_TARGET_COMPAT_REVISION"; then
+        LPAC_INSTALL_REASON="compatibility bundle revision ${installed_compat_revision:-0} -> ${LPAC_TARGET_COMPAT_REVISION}"
+        return 0
+      fi
+    fi
   fi
 
   if version_lt "$current_version" "$LPAC_TARGET_RELEASE_VERSION"; then
@@ -679,6 +881,7 @@ install_lpac() {
   lpac_dst="${INSTALL_DIR}/lpac"
   lpac_archive="${tmp_dir}/lpac.zip"
   lpac_extract="${tmp_dir}/lpac-extract"
+  lpac_stage="${tmp_dir}/lpac-stage"
 
   if ! truthy "$SIMADMIN_INSTALL_LPAC"; then
     echo "==> skipping lpac install (SIMADMIN_INSTALL_LPAC=${SIMADMIN_INSTALL_LPAC})"
@@ -717,20 +920,40 @@ install_lpac() {
     return 0
   fi
 
-  if copy_lpac_tree "$lpac_extract" "$lpac_dst" "$lpac_url"; then
-    detected_version="$(lpac_command_version "${lpac_dst}/lpac" || true)"
+  if copy_lpac_tree "$lpac_extract" "$lpac_stage" "$lpac_url"; then
+    detected_version="$(lpac_command_version "${lpac_stage}/lpac" || true)"
     if [ -z "$detected_version" ]; then
       detected_version="$LPAC_TARGET_RELEASE_VERSION"
     fi
-    write_lpac_version_file "$lpac_dst" "$detected_version"
-    if lpac_binary_usable "$lpac_dst"; then
-      if [ -n "$detected_version" ]; then
-        echo "==> lpac ${detected_version} installed to ${lpac_dst}"
-      else
-        echo "==> lpac installed to ${lpac_dst}"
+    write_lpac_version_file "$lpac_stage" "$detected_version"
+    write_lpac_compat_revision_file "$lpac_stage" "$LPAC_TARGET_COMPAT_REVISION"
+    if ! lpac_binary_usable "$lpac_stage"; then
+      echo "warning: downloaded lpac does not provide the required qmi/curl drivers or has missing libraries; keeping existing lpac" >&2
+      return 0
+    fi
+
+    lpac_previous="${lpac_dst}.previous"
+    rm -rf "$lpac_previous"
+    had_existing=0
+    if [ -e "$lpac_dst" ] || [ -L "$lpac_dst" ]; then
+      mv "$lpac_dst" "$lpac_previous"
+      had_existing=1
+    fi
+    if ! mv "$lpac_stage" "$lpac_dst"; then
+      if [ "$had_existing" -eq 1 ]; then
+        mv "$lpac_previous" "$lpac_dst" || true
       fi
+      echo "warning: failed to activate lpac, restored previous installation" >&2
+      return 0
+    fi
+    if [ "$had_existing" -eq 1 ]; then
+      rm -rf "$lpac_previous"
+    fi
+
+    if [ -n "$detected_version" ]; then
+      echo "==> lpac ${detected_version} installed to ${lpac_dst}"
     else
-      echo "warning: lpac was installed but may not be executable on this device; check glibc/architecture compatibility" >&2
+      echo "==> lpac installed to ${lpac_dst}"
     fi
   else
     echo "warning: failed to install lpac, keeping existing lpac if present" >&2
@@ -741,9 +964,14 @@ install_lpac() {
 
 main() {
   require_root
-  require_cmd curl
   require_cmd systemctl
   require_cmd mktemp
+
+  install_system_dependencies
+  require_cmd curl
+  remove_legacy_networkmanager_modem_unmanaged
+  start_runtime_services
+  refresh_modem_devices
 
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "$tmp_dir"' EXIT INT TERM
@@ -777,6 +1005,21 @@ main() {
     exit 1
   fi
 
+  expected_arch="$(detect_simadmin_arch)-unknown-linux-musl"
+  if [ -f "${tmp_dir}/pkg/meta.json" ]; then
+    package_arch="$(json_string_field arch < "${tmp_dir}/pkg/meta.json")"
+    if [ -z "$package_arch" ]; then
+      echo "error: invalid package, meta.json is missing arch" >&2
+      exit 1
+    fi
+    if [ "$package_arch" != "$expected_arch" ]; then
+      echo "error: package architecture mismatch: expected $expected_arch, got $package_arch" >&2
+      exit 1
+    fi
+  else
+    echo "warning: package has no meta.json; architecture could not be verified" >&2
+  fi
+
   echo "==> stopping existing service"
   systemctl stop "${SERVICE_NAME}.service" >/dev/null 2>&1 || true
 
@@ -798,8 +1041,6 @@ main() {
   echo "==> installing modem recovery service"
   install_modem_recovery_service
 
-  configure_networkmanager_modem_unmanaged
-
   echo "==> starting service"
   systemctl restart "${SERVICE_NAME}.service"
 
@@ -810,4 +1051,6 @@ main() {
   systemctl status "${SERVICE_NAME}.service" --no-pager
 }
 
-main "$@"
+if [ "${SIMADMIN_INSTALL_LIBRARY_ONLY:-0}" != "1" ]; then
+  main "$@"
+fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,23 @@ set -euo pipefail
 # 切换到项目根目录
 cd "$(dirname "$0")/.."
 
-TARGET="aarch64-unknown-linux-musl"
+TARGET="${TARGET:-aarch64-unknown-linux-musl}"
+
+normalize_target() {
+    case "$1" in
+        aarch64|arm64|aarch64-unknown-linux-musl)
+            echo "aarch64-unknown-linux-musl"
+            ;;
+        x86_64|amd64|x86_64-unknown-linux-musl)
+            echo "x86_64-unknown-linux-musl"
+            ;;
+        *)
+            echo "❌ 错误: 不支持的构建目标: $1" >&2
+            echo "支持: aarch64-unknown-linux-musl, x86_64-unknown-linux-musl" >&2
+            exit 1
+            ;;
+    esac
+}
 
 is_macos() {
     [[ "${OSTYPE:-}" == darwin* ]]
@@ -43,7 +59,7 @@ run_sed_in_place() {
 print_windows_notice() {
     if is_windows_bash; then
         echo "⚠️  检测到 Windows Bash 环境。"
-        echo "   完整 OTA 后端需要 Linux aarch64 musl 交叉工具链。"
+        echo "   完整 OTA 后端需要 Linux musl 交叉工具链 ($TARGET)。"
         echo "   推荐在 WSL2 Ubuntu 中运行: ./scripts/build.sh --no-upx"
         echo ""
     fi
@@ -78,6 +94,9 @@ for arg in "$@"; do
         --no-ota)
             SKIP_OTA=true
             ;;
+        --target=*)
+            TARGET="${arg#*=}"
+            ;;
         --help|-h)
             echo "用法: ./scripts/build.sh [选项]"
             echo ""
@@ -86,6 +105,7 @@ for arg in "$@"; do
             echo "  --frontend-only  只构建前端"
             echo "  --no-upx         禁用 UPX 压缩 (默认启用)"
             echo "  --no-ota         跳过 OTA 包生成"
+            echo "  --target=TARGET   构建目标: aarch64 或 x86_64 (默认: aarch64)"
             echo "  --help, -h       显示帮助信息"
             echo ""
             echo "示例:"
@@ -93,10 +113,13 @@ for arg in "$@"; do
             echo "  ./scripts/build.sh --no-upx           # 不压缩"
             echo "  ./scripts/build.sh --no-ota           # 不生成 OTA 包"
             echo "  ./scripts/build.sh --frontend-only    # 仅构建前端"
+            echo "  ./scripts/build.sh --target=x86_64    # 构建 x86_64 OTA 包"
             exit 0
             ;;
     esac
 done
+
+TARGET="$(normalize_target "$TARGET")"
 
 print_windows_notice
 
@@ -175,31 +198,36 @@ if [ "$BUILD_BACKEND" = true ]; then
         fi
     fi
 
-    # 检查交叉编译器
-    if ! command -v aarch64-unknown-linux-musl-gcc &> /dev/null; then
-        echo "❌ 错误: 未找到 aarch64-unknown-linux-musl-gcc"
-        echo ""
-        echo "请安装 aarch64 Linux musl 交叉编译工具链。"
-        if is_windows_bash; then
-            echo "Windows 原生环境不建议直接构建后端 OTA 包，推荐使用 WSL2 Ubuntu。"
-        fi
-        echo ""
-        echo "macOS 可参考:"
-        echo "  brew tap messense/macos-cross-toolchains"
-        echo "  brew install aarch64-unknown-linux-musl"
-        echo ""
-        echo "WSL/Linux 请安装可提供 aarch64-unknown-linux-musl-gcc 的交叉工具链，"
-        echo "或使用 GitHub Actions 的 OTA 打包工作流。"
-        exit 1
-    fi
+    case "$TARGET" in
+        aarch64-unknown-linux-musl)
+            MUSL_CC="aarch64-unknown-linux-musl-gcc"
+            if ! command -v "$MUSL_CC" >/dev/null 2>&1; then
+                echo "❌ 错误: 未找到 $MUSL_CC"
+                echo "请安装 aarch64 Linux musl 交叉编译工具链，或使用 GitHub Actions。"
+                exit 1
+            fi
+            export CC_aarch64_unknown_linux_musl="$MUSL_CC"
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="$MUSL_CC"
+            ;;
+        x86_64-unknown-linux-musl)
+            if command -v x86_64-unknown-linux-musl-gcc >/dev/null 2>&1; then
+                MUSL_CC="x86_64-unknown-linux-musl-gcc"
+            elif [[ "$(uname -s)" == "Linux" && "$(uname -m)" == "x86_64" ]] \
+                && command -v musl-gcc >/dev/null 2>&1; then
+                MUSL_CC="musl-gcc"
+            else
+                echo "❌ 错误: 未找到 x86_64 musl 编译器"
+                echo "请安装 x86_64-unknown-linux-musl-gcc；x86_64 Linux 也可安装 musl-tools。"
+                exit 1
+            fi
+            export CC_x86_64_unknown_linux_musl="$MUSL_CC"
+            export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="$MUSL_CC"
+            ;;
+    esac
     
     cd backend
 
     # 设置交叉编译环境变量
-    export CC_aarch64_unknown_linux_musl=aarch64-unknown-linux-musl-gcc
-    export CXX_aarch64_unknown_linux_musl=aarch64-unknown-linux-musl-g++
-    export AR_aarch64_unknown_linux_musl=aarch64-unknown-linux-musl-ar
-    export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-unknown-linux-musl-gcc
     export SQLITE3_STATIC=1
     export LIBSQLITE3_SYS_USE_PKG_CONFIG=0
 
@@ -334,7 +362,7 @@ EOF
         mkdir -p release
         
         # 打包
-        OTA_FILE="release/simadmin_${VERSION}.tar.gz"
+        OTA_FILE="release/simadmin_${VERSION}_${TARGET}.tar.gz"
         echo "打包 OTA..."
         cd "$OTA_TMP"
         tar -czf - meta.json simadmin www > "$OLDPWD/$OTA_FILE"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,6 +12,7 @@ TARGET_PATH="/opt/simadmin"
 DEPLOY_BACKEND=true
 DEPLOY_FRONTEND=true
 RESTART_SERVICE=true
+BUILD_TARGET="${TARGET:-aarch64-unknown-linux-musl}"
 
 # 解析命令行参数
 for arg in "$@"; do
@@ -28,6 +29,9 @@ for arg in "$@"; do
         --target=*)
             TARGET_PATH="${arg#*=}"
             ;;
+        --build-target=*)
+            BUILD_TARGET="${arg#*=}"
+            ;;
         --help|-h)
             echo "用法: ./scripts/deploy.sh [选项]"
             echo ""
@@ -36,6 +40,7 @@ for arg in "$@"; do
             echo "  --frontend-only  只部署前端"
             echo "  --no-restart     不重启服务（默认会停止现有服务）"
             echo "  --target=PATH    指定目标路径 (默认: /opt/simadmin)"
+            echo "  --build-target=TARGET  后端构建目标: aarch64 或 x86_64"
             echo "  --help, -h       显示帮助信息"
             echo ""
             echo "示例:"
@@ -55,7 +60,17 @@ for arg in "$@"; do
     esac
 done
 
-BACKEND_BIN="backend/target/aarch64-unknown-linux-musl/release/simadmin"
+case "$BUILD_TARGET" in
+    aarch64|arm64) BUILD_TARGET="aarch64-unknown-linux-musl" ;;
+    x86_64|amd64) BUILD_TARGET="x86_64-unknown-linux-musl" ;;
+    aarch64-unknown-linux-musl|x86_64-unknown-linux-musl) ;;
+    *)
+        echo "❌ 错误: 不支持的后端构建目标: $BUILD_TARGET" >&2
+        exit 1
+        ;;
+esac
+
+BACKEND_BIN="backend/target/$BUILD_TARGET/release/simadmin"
 FRONTEND_DIR="frontend/dist"
 
 echo "🚀 通过 ADB 部署到 ${TARGET_PATH}"

--- a/scripts/pack-ota.sh
+++ b/scripts/pack-ota.sh
@@ -1,12 +1,42 @@
 #!/bin/bash
 
 # 打包 OTA 更新包
-# 输出: release/simadmin_{version}.tar.gz
+# 输出: release/simadmin_{version}_{target}.tar.gz
 
 set -e
 
 # 切换到项目根目录
 cd "$(dirname "$0")/.."
+
+TARGET="${TARGET:-aarch64-unknown-linux-musl}"
+for arg in "$@"; do
+    case "$arg" in
+        --target=aarch64|--target=arm64|--target=aarch64-unknown-linux-musl)
+            TARGET="aarch64-unknown-linux-musl"
+            ;;
+        --target=x86_64|--target=amd64|--target=x86_64-unknown-linux-musl)
+            TARGET="x86_64-unknown-linux-musl"
+            ;;
+        --help|-h)
+            echo "用法: ./scripts/pack-ota.sh [--target=aarch64|x86_64]"
+            exit 0
+            ;;
+        *)
+            echo "❌ 错误: 未知选项: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
+
+case "$TARGET" in
+    aarch64|arm64) TARGET="aarch64-unknown-linux-musl" ;;
+    x86_64|amd64) TARGET="x86_64-unknown-linux-musl" ;;
+    aarch64-unknown-linux-musl|x86_64-unknown-linux-musl) ;;
+    *)
+        echo "❌ 错误: 不支持的构建目标: $TARGET" >&2
+        exit 1
+        ;;
+esac
 
 echo "=========================================="
 echo "  打包 OTA 更新包"
@@ -33,10 +63,10 @@ fi
 BUILD_TIME=$(TZ=Asia/Shanghai date +"%Y-%m-%dT%H:%M:%S+08:00")
 
 # 目标架构
-ARCH="aarch64-unknown-linux-musl"
+ARCH="$TARGET"
 
 # 检查构建产物
-BINARY_PATH="backend/target/aarch64-unknown-linux-musl/release/simadmin"
+BINARY_PATH="backend/target/$TARGET/release/simadmin"
 FRONTEND_DIR="frontend/dist"
 
 if [ ! -f "$BINARY_PATH" ]; then
@@ -110,7 +140,7 @@ echo ""
 mkdir -p release
 
 # 打包
-OTA_FILE="release/simadmin_${VERSION}.tar.gz"
+OTA_FILE="release/simadmin_${VERSION}_${TARGET}.tar.gz"
 echo "📦 打包 OTA 更新包..."
 cd "$OTA_TMP"
 tar -czf - meta.json simadmin www > "$OLDPWD/$OTA_FILE"

--- a/tests/install_latest_test.sh
+++ b/tests/install_latest_test.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+SIMADMIN_INSTALL_LIBRARY_ONLY=1
+REPO=monlor/SimAdmin
+unset LPAC_COMPAT_RELEASE_BASE_URL
+export SIMADMIN_INSTALL_LIBRARY_ONLY
+. "${repo_root}/install_latest.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  expected="$1"
+  actual="$2"
+  message="$3"
+  if [ "$actual" != "$expected" ]; then
+    fail "${message}: expected '${expected}', got '${actual}'"
+  fi
+}
+
+LPAC_ASSET_FLAVOR=compat
+assert_eq \
+  "https://github.com/monlor/SimAdmin/releases/download/lpac" \
+  "$LPAC_COMPAT_RELEASE_BASE_URL" \
+  "compatibility release must follow REPO"
+
+assert_eq \
+  "lpac-linux-x86_64-glibc2.31.zip" \
+  "$(resolve_lpac_compat_asset_name x86_64 2.39)" \
+  "x86_64 compat asset must use the bundled-libqmi build"
+
+assert_eq \
+  "lpac-linux-x86_64-glibc2.31.zip" \
+  "$(resolve_lpac_compat_asset_name x86_64 2.31)" \
+  "x86_64 compat asset must support the glibc baseline"
+
+LPAC_TARGET_ARCH=x86_64
+LPAC_ASSET_NAME=lpac-linux-x86_64-glibc2.31.zip
+assert_eq \
+  "${LPAC_COMPAT_RELEASE_BASE_URL}/lpac-linux-x86_64-glibc2.31.zip" \
+  "$(resolve_lpac_asset_url)" \
+  "x86_64 compatibility asset must be downloaded from the SimAdmin release"
+LPAC_TARGET_ARCH=
+LPAC_ASSET_NAME=
+
+LPAC_ASSET_FLAVOR=with-qmi
+assert_eq \
+  "lpac-linux-aarch64-with-qmi.zip" \
+  "$(resolve_lpac_asset_name aarch64)" \
+  "explicit with-qmi flavor"
+
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT INT TERM
+
+cat > "${test_dir}/lpac-qmi" <<'EOF'
+#!/bin/sh
+printf '%s\n' '{"type":"driver","payload":{"LPAC_APDU":["qmi","stdio"],"LPAC_HTTP":["curl","stdio"]}}'
+EOF
+chmod 0755 "${test_dir}/lpac-qmi"
+
+cat > "${test_dir}/lpac-no-qmi" <<'EOF'
+#!/bin/sh
+printf '%s\n' '{"type":"driver","payload":{"LPAC_APDU":["pcsc","at","stdio"],"LPAC_HTTP":["curl","stdio"]}}'
+EOF
+chmod 0755 "${test_dir}/lpac-no-qmi"
+
+lpac_binary_path_usable "${test_dir}/lpac-qmi" \
+  || fail "QMI-capable lpac should pass the installer probe"
+
+if lpac_binary_path_usable "${test_dir}/lpac-no-qmi"; then
+  fail "lpac without QMI must fail the installer probe"
+fi
+
+read_with_proxies() {
+  printf '%s\n' '{"version":"v2.3.0","compat_revision":"2","assets":[{"name":"lpac-linux-x86_64-glibc2.31.zip","arch":"x86_64"}]}'
+}
+
+compat_existing="${test_dir}/compat-existing"
+mkdir -p "$compat_existing"
+cp "${test_dir}/lpac-qmi" "${compat_existing}/lpac"
+printf '%s\n' 2.3.0 > "${compat_existing}/VERSION.txt"
+printf '%s\n' 1 > "${compat_existing}/COMPAT_REVISION.txt"
+if ! lpac_install_needed \
+  "${compat_existing}/lpac" \
+  "${LPAC_COMPAT_RELEASE_BASE_URL}/lpac-linux-x86_64-glibc2.31.zip"; then
+  fail "newer compatibility bundle revision must trigger an lpac upgrade"
+fi
+assert_eq 2 "$LPAC_TARGET_COMPAT_REVISION" \
+  "compatibility manifest revision must be retained for installation"
+
+download_with_proxies() {
+  :
+}
+
+extract_lpac_archive() {
+  mkdir -p "$2"
+  cp "${test_dir}/lpac-qmi" "$2/lpac"
+}
+
+lpac_install_needed() {
+  LPAC_INSTALL_REASON="test install"
+  return 0
+}
+
+install_root="${test_dir}/install-root"
+tmp_dir="${test_dir}/install-tmp"
+INSTALL_DIR="$install_root"
+LPAC_TARGET_ARCH=x86_64
+LPAC_ASSET_NAME=lpac-linux-x86_64-glibc2.31.zip
+LPAC_ASSET_FLAVOR=compat
+LPAC_TARGET_RELEASE_VERSION=
+mkdir -p "${INSTALL_DIR}/lpac"
+printf '%s\n' old > "${INSTALL_DIR}/lpac/previous-marker"
+
+install_lpac
+
+[ -x "${INSTALL_DIR}/lpac/lpac" ] \
+  || fail "validated lpac stage must be activated at the install destination"
+[ ! -e "${INSTALL_DIR}/lpac/previous-marker" ] \
+  || fail "previous lpac tree must be replaced after successful activation"
+[ ! -e "${INSTALL_DIR}/lpac.previous" ] \
+  || fail "previous lpac tree must be cleaned after successful activation"
+
+echo "install_latest tests passed"


### PR DESCRIPTION
## What changed

- Build, package, release, install, and OTA-select native x86_64/amd64 assets alongside ARM64.
- Validate each OTA package against the running target architecture and retain the legacy asset fallback only for ARM64.
- Build x86_64 and ARM64 lpac compatibility bundles with a bundled libqmi, and make eSIM repair verify a usable installed binary.

## Why

The original distribution path only covered ARM64. On x86_64, upstream lpac also requires a newer libqmi ABI than Ubuntu 24.04 supplies; the compatibility bundle removes that host-library dependency without changing ModemManager.

## Validation

- cargo test --locked (111 passed)
- bash tests/install_latest_test.sh
- pnpm lint and pnpm build
- actionlint v1.7.12 for both modified workflows
- git diff --check

## Notes

This is a single-commit consolidation of PR #22 and PR #23.